### PR TITLE
Allow overloading the ProcessedMessage constructor

### DIFF
--- a/src/History/Model/ProcessedMessage.php
+++ b/src/History/Model/ProcessedMessage.php
@@ -47,7 +47,7 @@ abstract class ProcessedMessage
     /** @var Structure[]|Results */
     private array|Results $results;
 
-    final public function __construct(Envelope $envelope, Results $results, ?\Throwable $exception = null)
+    public function __construct(Envelope $envelope, Results $results, ?\Throwable $exception = null)
     {
         $monitorStamp = $envelope->last(MonitorStamp::class) ?? throw new \LogicException('Required stamp not available');
         $type = new Type($envelope->getMessage());


### PR DESCRIPTION
We have custom Ulid IDs, and having the constructor `final` would mean to introduce auto-incremental IDs.
Removing final would allow the userland developers to have their custom ID types.