### PR TITLE
docs: add more infos for messenger:monitor:purge

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,10 +143,12 @@ add your own in one of two ways:
 
 If your app handles a lot of messages, the processed message database table will get very large.
 The `messenger:monitor:purge` clears messages older than a specific date:
+See [`Period`](https://github.com/zenstruck/messenger-monitor-bundle/blob/1.x/src/History/Period.php#L19) for allowed values.
 
 ```bash
 bin/console messenger:monitor:purge # by default, purges all messages older than 1 month
 
+bin/console messenger:monitor:purge --older-than all
 bin/console messenger:monitor:purge --older-than 1-day
 bin/console messenger:monitor:purge --older-than 1-week
 


### PR DESCRIPTION
My first though was, that these are the same values as in DateTime. Just with the ` ` replaced by `-`.
Maybe this could help other developers.