### PR TITLE
fix: live-component for transports

### DIFF
--- a/src/Twig/Component/TransportsComponent.php
+++ b/src/Twig/Component/TransportsComponent.php
@@ -12,6 +12,8 @@
 namespace Zenstruck\Messenger\Monitor\Twig\Component;
 
 use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
+use Symfony\UX\TwigComponent\Attribute\ExposeInTemplate;
+use Zenstruck\Messenger\Monitor\Transports;
 use Zenstruck\Messenger\Monitor\Twig\Component;
 
 /**
@@ -23,4 +25,9 @@ use Zenstruck\Messenger\Monitor\Twig\Component;
 )]
 class TransportsComponent extends Component
 {
+    #[ExposeInTemplate]
+    public function transports(): Transports
+    {
+        return $this->helper->transports;
+    }
 }


### PR DESCRIPTION
With activated live components i did get an error, that 'transports' is not defined on the overwiew page.
I copied and modified the code from WorkerComponent.