### PR TITLE
fix: filter history for tags (WIP)

### DIFF
--- a/src/History/Storage/ORMStorage.php
+++ b/src/History/Storage/ORMStorage.php
@@ -169,11 +169,11 @@ final class ORMStorage implements Storage
         };
 
         foreach ($tags as $i => $tag) {
-            $qb->andWhere('m.tags LIKE :tag'.$i)->setParameter('tag'.$i, '%'.$tag.'%');
+            $qb->andWhere('CAST(m.tags as varchar) LIKE :tag'.$i)->setParameter('tag'.$i, '%'.$tag.'%');
         }
 
         foreach ($notTags as $i => $notTag) {
-            $qb->andWhere('m.tags NOT LIKE :not_tag'.$i)->setParameter('not_tag'.$i, '%'.$notTag.'%');
+            $qb->andWhere('CAST(m.tags as varchar) NOT LIKE :not_tag'.$i)->setParameter('not_tag'.$i, '%'.$notTag.'%');
         }
 
         if ($order) {


### PR DESCRIPTION
If i try to filter for a tag i get an dql error.
/admin/messenger/history?tag=foo

```
Undefined function: 7 ERROR: operator does not exist: json ~~ unknown
LINE 1: ...t >= $1 AND p0_.failure_type IS NULL AND p0_.tags LIKE $2 GR...
^
HINT: No operator matches the given name and argument types. You might need to add explicit type casts.").
```

The problem is the filtering for an array. Another solution could be to use the type `simple_array`

I am not sure if this is specific to postgres, and works in mysql?
Would be great if someone could test this with mysql.

