### PR TITLE
feat: add badge for environment info

### DIFF
--- a/templates/layout.html.twig
+++ b/templates/layout.html.twig
@@ -112,7 +112,7 @@
         <div class="container-fluid">
             <a href="{{ path('zenstruck_messenger_monitor_dashboard') }}" class="navbar-brand">
                 {{ include('@ZenstruckMessengerMonitor/icon.svg.twig', {size: 24, class: 'd-inline-block align-text-top '~(helper.workers.isRunning ? 'text-success' : 'text-danger')}) }}
-                Messenger Monitor
+                Messenger Monitor <div class="badge bg-secondary environment-info">{{ app.environment }}</div>
             </a>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>


### PR DESCRIPTION
This would help to better see in which environment the data is for.
Of course layout and design can be changed.