### PR TITLE
set default $limit to 500 on transportInfo

### DIFF
--- a/src/Transport/TransportInfo.php
+++ b/src/Transport/TransportInfo.php
@@ -64,7 +64,7 @@ final class TransportInfo implements \IteratorAggregate, \Countable
     /**
      * @return Collection<int,QueuedMessage>
      */
-    public function list(?int $limit = null): Collection
+    public function list(?int $limit = 500): Collection
     {
         if (!$this->transport instanceof ListableReceiverInterface) {
             throw new \LogicException(\sprintf('Transport "%s" does not implement "%s".', $this->name, ListableReceiverInterface::class));


### PR DESCRIPTION
This work around for large data and in order to keep the dashboard running, 