### PR TITLE
feat: allow symfony 7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
           - php: 8.1
             deps: lowest
             symfony: '*'
+          - php: 8.3
+            symfony: '7.0.*'
     steps:
       - uses: zenstruck/.github@php-test-symfony
         with:

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
     ],
     "require": {
         "php": ">=8.1",
-        "symfony/framework-bundle": "^6.3",
-        "symfony/messenger": "^6.3",
+        "symfony/framework-bundle": "^6.3|^7.0",
+        "symfony/messenger": "^6.3|^7.0",
         "zenstruck/bytes": "^0.2.0",
         "zenstruck/collection": "^0.2.2"
     },
@@ -26,17 +26,17 @@
         "matthiasnoback/symfony-dependency-injection-test": "^4.3",
         "phpstan/phpstan": "^1.4",
         "phpunit/phpunit": "^9.6.0",
-        "symfony/asset-mapper": "^6.3",
-        "symfony/console": "^6.3",
+        "symfony/asset-mapper": "^6.3|^7.0",
+        "symfony/console": "^6.3|^7.0",
         "symfony/http-client-contracts": "^3.3",
-        "symfony/mailer": "^6.3",
-        "symfony/phpunit-bridge": "^6.1",
-        "symfony/process": "^6.3",
-        "symfony/scheduler": "^6.3",
-        "symfony/security-bundle": "^6.3",
+        "symfony/mailer": "^6.3|^7.0",
+        "symfony/phpunit-bridge": "^6.1|^7.0",
+        "symfony/process": "^6.3|^7.0",
+        "symfony/scheduler": "^6.3|^7.0",
+        "symfony/security-bundle": "^6.3|^7.0",
         "symfony/ux-live-component": "^2.10",
-        "symfony/var-dumper": "^5.4|^6.0",
-        "zenstruck/console-test": "^1.4"
+        "symfony/var-dumper": "^5.4|^6.0|^7.0",
+        "zenstruck/console-test": "^1.5"
     },
     "suggest": {
         "knplabs/knp-time-bundle": "For human readable timestamps and durations on your dashboard.",

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "symfony/scheduler": "^6.3|^7.0",
         "symfony/security-bundle": "^6.3|^7.0",
         "symfony/ux-live-component": "^2.10",
-        "symfony/var-dumper": "^5.4|^6.0|^7.0",
+        "symfony/var-dumper": "^6.3|^7.0",
         "zenstruck/console-test": "^1.5"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "doctrine/orm": "^2.15",
         "knplabs/knp-time-bundle": "^1.20|^2.0",
         "lorisleiva/cron-translator": "^0.4.3",
-        "matthiasnoback/symfony-dependency-injection-test": "^4.3",
+        "matthiasnoback/symfony-dependency-injection-test": "^4.3|^5.0",
         "phpstan/phpstan": "^1.4",
         "phpunit/phpunit": "^9.6.0",
         "symfony/asset-mapper": "^6.3|^7.0",


### PR DESCRIPTION
Blocked by https://github.com/SymfonyTest/SymfonyDependencyInjectionTest/pull/149 and by knplabs/knp-time-bundle https://github.com/KnpLabs/KnpTimeBundle/blob/main/composer.json#L20
Update: I created a PR: https://github.com/KnpLabs/KnpTimeBundle/pull/202

Is there a reason that var-dumper version constraints are different from the others form symfony? https://github.com/zenstruck/messenger-monitor-bundle/compare/1.x...Chris53897:feature/allow-symfony-7?expand=1#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34R38

zenstruck/console-test is bumped to 1.5 for a prefer-lowest run.