### PR TITLE
Add input data to processed messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,28 @@ You may want to disable monitoring for certain messages. There are several ways 
                 - App\Message\MyMessage
     ```
 
+#### Disable Input Monitoring
+
+You may want to disable monitoring for certain messages (example: emails with attachments). There are two ways to do this:
+
+1. When dispatching the message, add the `DisableInputStoreStamp`:
+    ```php
+    use Zenstruck\Messenger\Monitor\Stamp\DisableInputStoreStamp;
+
+    /** @var \Symfony\Component\Messenger\MessageBusInterface $bus */
+
+    $bus->dispatch(new MyMessage(), [new DisableInputStoreStamp()])
+    ```
+2. Add the `DisableInputStoreStamp` as a class attribute to your message:
+    ```php
+    use Zenstruck\Messenger\Monitor\Stamp\DisableInputStoreStamp;
+
+    #[DisableInputStoreStamp]
+    class MyMessage
+    {
+    }
+    ```
+
 #### Description
 
 The stored `ProcessedMessage` has a description property. This is helpful to differentiate between

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
         "php": ">=8.1",
         "symfony/framework-bundle": "^6.4.1|^7.0|^8.0",
         "symfony/messenger": "^6.4|^7.0|^8.0",
+        "symfony/serializer": "^6.4|^7.0|^8.0",
         "zenstruck/bytes": "^1.0",
         "zenstruck/collection": "^0.8"
     },
@@ -34,7 +35,6 @@
         "symfony/process": "^6.4|^7.0|^8.0",
         "symfony/scheduler": "^6.4|^7.0|^8.0",
         "symfony/security-bundle": "^6.4|^7.0|^8.0",
-        "symfony/serializer": "^6.4|^7.0|^8.0",
         "symfony/var-dumper": "^6.4|^7.0|^8.0",
         "zenstruck/console-test": "^1.5",
         "zenstruck/foundry": "^2.2",

--- a/config/doctrine/mapping/ProcessedMessage.orm.xml
+++ b/config/doctrine/mapping/ProcessedMessage.orm.xml
@@ -7,6 +7,7 @@
         <field name="runId" column="run_id" type="integer" />
         <field name="attempt" column="attempt" type="smallint" />
         <field name="type" column="message_type" />
+        <field name="input" column="input" type="json" nullable="true"/>
         <field name="description" column="description" nullable="true" />
         <field name="dispatchedAt" column="dispatched_at" type="datetime_immutable" />
         <field name="receivedAt" column="received_at" type="datetime_immutable" />

--- a/config/storage_orm.php
+++ b/config/storage_orm.php
@@ -45,6 +45,7 @@ return static function (ContainerConfigurator $container): void {
             ->args([
                 service('zenstruck_messenger_monitor.history.storage'),
                 service('.zenstruck_messenger_monitor.history.result_normalizer'),
+                service('messenger.default_serializer'),
             ])
             ->tag('kernel.event_listener', ['method' => 'handleSuccess', 'event' => WorkerMessageHandledEvent::class, 'priority' => -100])
             ->tag('kernel.event_listener', ['method' => 'handleFailure', 'event' => WorkerMessageFailedEvent::class, 'priority' => -100])

--- a/src/Controller/MessengerMonitorController.php
+++ b/src/Controller/MessengerMonitorController.php
@@ -19,10 +19,12 @@ use Symfony\Component\Messenger\Message\RedispatchMessage;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Messenger\Stamp\SentToFailureTransportStamp;
 use Symfony\Component\Messenger\Stamp\TransportNamesStamp;
+use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Scheduler\Generator\MessageContext;
 use Symfony\Component\Scheduler\Trigger\CronExpressionTrigger;
 use Symfony\Component\Scheduler\Trigger\TriggerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Zenstruck\Messenger\Monitor\History\Period;
 use Zenstruck\Messenger\Monitor\History\Specification;
 use Zenstruck\Messenger\Monitor\Schedules;
@@ -96,16 +98,23 @@ abstract class MessengerMonitorController extends AbstractController
     }
 
     #[Route('/history/{id}', name: 'zenstruck_messenger_monitor_detail')]
-    public function detail(string $id, ViewHelper $helper): Response
+    public function detail(string $id, ViewHelper $helper, SerializerInterface $serializer, NormalizerInterface $normalizer): Response
     {
         if (!$message = $helper->storage()->find($id)) {
             throw $this->createNotFoundException('Message not found.');
+        }
+
+        $inputMessage = [];
+        if ($message->input() && array_key_exists('body', $message->input())) {
+            $inputMessage = $serializer->decode($message->input())->getMessage();
+            $inputMessage = $normalizer->normalize($inputMessage);
         }
 
         return $this->render('@ZenstruckMessengerMonitor/detail.html.twig', [
             'helper' => $helper,
             'message' => $message,
             'other_attempts' => $helper->storage()->filter(Specification::create(['run_id' => $message->runId()])),
+            'inputMessage' => $inputMessage,
         ]);
     }
 

--- a/src/EventListener/HandleMonitorStampListener.php
+++ b/src/EventListener/HandleMonitorStampListener.php
@@ -16,9 +16,11 @@ use Symfony\Component\Messenger\Event\WorkerMessageFailedEvent;
 use Symfony\Component\Messenger\Event\WorkerMessageHandledEvent;
 use Symfony\Component\Messenger\Exception\HandlerFailedException;
 use Symfony\Component\Messenger\Stamp\HandledStamp;
+use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 use Zenstruck\Messenger\Monitor\History\Model\Results;
 use Zenstruck\Messenger\Monitor\History\ResultNormalizer;
 use Zenstruck\Messenger\Monitor\History\Storage;
+use Zenstruck\Messenger\Monitor\Stamp\DisableInputStoreStamp;
 use Zenstruck\Messenger\Monitor\Stamp\MonitorStamp;
 
 /**
@@ -31,6 +33,7 @@ final class HandleMonitorStampListener
     public function __construct(
         private Storage $storage,
         private ResultNormalizer $normalizer,
+        private SerializerInterface $serializer
     ) {
     }
 
@@ -46,7 +49,13 @@ final class HandleMonitorStampListener
 
         $event->addStamps($stamp->markFinished());
 
-        $this->storage->save($event->getEnvelope(), $this->createResults($event->getEnvelope()));
+        $input = null;
+        if (!$this->isInputMonitoringDisabled($event->getEnvelope())) {
+            /** @var array{body: string, headers?: array<string, string>} $input */
+            $input = $this->serializer->encode($event->getEnvelope()->withoutAll(MonitorStamp::class));
+        }
+
+        $this->storage->save($event->getEnvelope(), $input, $this->createResults($event->getEnvelope()));
     }
 
     public function handleFailure(WorkerMessageFailedEvent $event): void
@@ -63,8 +72,15 @@ final class HandleMonitorStampListener
 
         $event->addStamps($stamp->markFinished());
 
+        $input = null;
+        if (!$this->isInputMonitoringDisabled($event->getEnvelope())) {
+            /** @var array{body: string, headers?: array<string, string>} $input */
+            $input = $this->serializer->encode($event->getEnvelope()->withoutAll(MonitorStamp::class));
+        }
+
         $this->storage->save(
             $event->getEnvelope(),
+            $input,
             $this->createResults($event->getEnvelope(), $throwable instanceof HandlerFailedException ? $throwable : null),
             $throwable,
         );
@@ -96,5 +112,22 @@ final class HandleMonitorStampListener
         }
 
         return new Results($results);
+    }
+
+    private function isInputMonitoringDisabled(Envelope $envelope): bool
+    {
+        if ($envelope->last(DisableInputStoreStamp::class)) {
+            return true;
+        }
+
+        $reflection = new \ReflectionClass($envelope->getMessage());
+        $attributes = [];
+
+        while (false !== $reflection && [] === $attributes) {
+            $attributes = $reflection->getAttributes(DisableInputStoreStamp::class);
+            $reflection = $reflection->getParentClass();
+        }
+
+        return [] !== $attributes;
     }
 }

--- a/src/History/Model/ProcessedMessage.php
+++ b/src/History/Model/ProcessedMessage.php
@@ -30,6 +30,9 @@ abstract class ProcessedMessage
 
     /** @var class-string */
     private string $type;
+
+    /** @var array{body: string, headers?: array<string, string>}|null $input */
+    private ?array $input = null;
     private ?string $description;
     private \DateTimeImmutable $dispatchedAt;
     private \DateTimeImmutable $receivedAt;
@@ -47,7 +50,8 @@ abstract class ProcessedMessage
     /** @var Structure[]|Results|null */
     private array|Results|null $results;
 
-    public function __construct(Envelope $envelope, Results $results, ?\Throwable $exception = null)
+    /** @param array{body: string, headers?: array<string, string>}|null $input */
+    public function __construct(Envelope $envelope, ?array $input, Results $results, ?\Throwable $exception = null)
     {
         $monitorStamp = $envelope->last(MonitorStamp::class) ?? throw new \LogicException('Required stamp not available');
         $type = new Type($envelope->getMessage());
@@ -55,6 +59,7 @@ abstract class ProcessedMessage
 
         $this->runId = $monitorStamp->runId();
         $this->type = $type->class();
+        $this->input = $input;
         $this->description = $envelope->last(DescriptionStamp::class)?->value ?? $type->description();
         $this->dispatchedAt = $monitorStamp->dispatchedAt();
         $this->receivedAt = $monitorStamp->receivedAt();
@@ -91,6 +96,12 @@ abstract class ProcessedMessage
     final public function type(): Type
     {
         return new Type($this->type);
+    }
+
+    /** @return array{body: string, headers?: array<string, string>}|null $input */
+    final public function input(): ?array
+    {
+        return $this->input;
     }
 
     final public function description(): ?string

--- a/src/History/Storage.php
+++ b/src/History/Storage.php
@@ -31,7 +31,8 @@ interface Storage
 
     public function purge(Specification $specification): int;
 
-    public function save(Envelope $envelope, Results $results, ?\Throwable $exception = null): void;
+    /** @param array{body: string, headers?: array<string, string>}|null $input */
+    public function save(Envelope $envelope, ?array $input, Results $results, ?\Throwable $exception = null): void;
 
     public function delete(mixed $id): void;
 

--- a/src/History/Storage/ORMStorage.php
+++ b/src/History/Storage/ORMStorage.php
@@ -83,10 +83,11 @@ final class ORMStorage implements Storage
         ;
     }
 
-    public function save(Envelope $envelope, Results $results, ?\Throwable $exception = null): void
+    /** @param array<string, string> $input */
+    public function save(Envelope $envelope, ?array $input, Results $results, ?\Throwable $exception = null): void
     {
         $om = $this->om();
-        $object = new $this->entityClass($envelope, $results, $exception);
+        $object = new $this->entityClass($envelope, $input, $results, $exception);
 
         $om->persist($object);
         $om->flush();

--- a/src/Stamp/DisableInputStoreStamp.php
+++ b/src/Stamp/DisableInputStoreStamp.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/messenger-monitor-bundle package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Messenger\Monitor\Stamp;
+
+use Symfony\Component\Messenger\Stamp\StampInterface;
+
+#[\Attribute(\Attribute::TARGET_CLASS)]
+final class DisableInputStoreStamp implements StampInterface
+{
+}

--- a/templates/detail.html.twig
+++ b/templates/detail.html.twig
@@ -105,6 +105,40 @@
             </div>
         </div>
         <div class="col-md-7">
+            <div class="card mb-3">
+                <div class="card-header">
+                    Input data
+                </div>
+                <table class="table card-table table-striped align-middle" style="table-layout: fixed; width: 100%;">
+                    {% for key,value in inputMessage %}
+                        <tr>
+                            <th class="text-end w-25">{{ key }}</th>
+                            <td>
+                                {% if value is same as true %}
+                                    <code>true</code>
+                                {% elseif value is same as false %}
+                                    <code>false</code>
+                                {% elseif value is same as null %}
+                                    <code>null</code>
+                                {% elseif value is iterable %}
+                                    <pre class="mb-0" style="white-space: pre; max-height: 340px; overflow: auto;">{{ value|json_encode(constant('JSON_PRETTY_PRINT')) }}</pre>
+                                {% elseif value matches "\/\n/" %}
+                                    <pre class="mb-0" style="white-space: pre; max-height: 340px; overflow: auto;">{{ value }}</pre>
+                                {% elseif value.value is defined %}
+                                    <code>{{ value.value }}</code>
+                                {% else %}
+                                    <code>{{ value }}</code>
+                                {% endif %}
+                            </td>
+                        </tr>
+                    {% else %}
+                        <tr>
+                            <td class="text-center text-secondary">No input data.</td>
+                        </tr>
+                    {% endfor %}
+                </table>
+            </div>
+
             {% for result in message.results %}
                 <div class="card mb-3">
                     <div class="card-header">

--- a/tests/Unit/EventListener/ReceiveMonitorStampListenerTest.php
+++ b/tests/Unit/EventListener/ReceiveMonitorStampListenerTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Event\WorkerMessageReceivedEvent;
 use Symfony\Component\Messenger\Stamp\HandledStamp;
+use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 use Symfony\Component\Scheduler\Generator\MessageContext;
 use Symfony\Component\Scheduler\Messenger\ScheduledStamp;
 use Symfony\Component\Scheduler\Trigger\TriggerInterface;

--- a/tests/Unit/History/Model/ProcessedMessageTest.php
+++ b/tests/Unit/History/Model/ProcessedMessageTest.php
@@ -48,7 +48,7 @@ final class ProcessedMessageTest extends TestCase
         $stamp = $stamp->markFinished();
 
         $envelope = new Envelope(new \stdClass(), [$stamp]);
-        $message = new class($envelope, new Results([])) extends ProcessedMessage {
+        $message = new class($envelope, ['some encoded envelope'], new Results([])) extends ProcessedMessage {
             public function id(): string|int|\Stringable|null
             {
                 return null;
@@ -71,6 +71,7 @@ final class ProcessedMessageTest extends TestCase
         $this->assertFalse($message->isFailure());
         $this->assertNull($message->failure());
         $this->assertTrue($message->memoryUsage()->isGreaterThan(0));
+        $this->assertSame(['some encoded envelope'], $message->input());
     }
 
     /**
@@ -88,7 +89,7 @@ final class ProcessedMessageTest extends TestCase
             new TagStamp('qux'),
         ]);
 
-        $message = new class($envelope, new Results([['exception' => \RuntimeException::class, 'message' => 'failure', 'data' => []]]), new \RuntimeException('fail')) extends ProcessedMessage {
+        $message = new class($envelope, ['some encoded envelope'], new Results([['exception' => \RuntimeException::class, 'message' => 'failure', 'data' => []]]), new \RuntimeException('fail')) extends ProcessedMessage {
             public function id(): string|int|null
             {
                 return null;
@@ -103,6 +104,7 @@ final class ProcessedMessageTest extends TestCase
         $this->assertTrue($message->isFailure());
         $this->assertSame('RuntimeException', (string) $message->failure());
         $this->assertSame('fail', $message->failure()?->description());
+        $this->assertSame(['some encoded envelope'], $message->input());
     }
 
     /**
@@ -112,7 +114,7 @@ final class ProcessedMessageTest extends TestCase
     {
         $this->expectException(\LogicException::class);
 
-        new class(new Envelope(new \stdClass()), new Results([])) extends ProcessedMessage {
+        new class(new Envelope(new \stdClass()), [], new Results([])) extends ProcessedMessage {
             public function id(): string|int|null
             {
                 return null;
@@ -130,7 +132,7 @@ final class ProcessedMessageTest extends TestCase
             new DescriptionStamp('description value'),
         ]);
 
-        $message = new class($envelope, new Results([])) extends ProcessedMessage {
+        $message = new class($envelope, [], new Results([])) extends ProcessedMessage {
             public function id(): string|int|null
             {
                 return null;
@@ -159,7 +161,7 @@ final class ProcessedMessageTest extends TestCase
         $stamp = $stamp->markFinished();
 
         $envelope = new Envelope(new \stdClass(), [$stamp]);
-        $message = new class($envelope, new Results([])) extends ProcessedMessage {
+        $message = new class($envelope, [], new Results([])) extends ProcessedMessage {
             public function id(): string|int|\Stringable|null
             {
                 return null;


### PR DESCRIPTION
Fixes #17

* Uses `symfony/serializer` to normalize the message from the envelope.
* Stores the data into the `input` field
* Didn't work on tests yet, until it's confirmed the approach is good

<img width="1164" alt="image" src="https://github.com/zenstruck/messenger-monitor-bundle/assets/438308/38311346-11d4-4948-a80c-ae783c3a62b0">
