### PR TITLE
test: adjust test for mac os

### DIFF
--- a/tests/History/ResultNormalizerTest.php
+++ b/tests/History/ResultNormalizerTest.php
@@ -149,7 +149,7 @@ final class ResultNormalizerTest extends TestCase
             $this->assertStringContainsString(__FUNCTION__, $result['stack_trace']);
             $this->assertSame(127, $result['exit_code']);
             $this->assertSame('', $result['output']);
-            $this->assertSame('sh: 1: exec: invalid: not found', $result['error_output']);
+            $this->assertStringContainsString('exec: invalid: not found', $result['error_output']);
 
             return;
         }


### PR DESCRIPTION
While running tests locally on my Mac M1 i get a failing test.

```
Failed asserting that two strings are identical.
Expected :'sh: 1: exec: invalid: not found'
Actual   :'sh: line 0: exec: invalid: not found'
```

I am not sure what is the best solution.