### PR TITLE
feat: bump zenstruck/collection to version 0.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "symfony/framework-bundle": "^6.3|^7.0",
         "symfony/messenger": "^6.3|^7.0",
         "zenstruck/bytes": "^1.0",
-        "zenstruck/collection": "^0.2.2"
+        "zenstruck/collection": "^0.3"
     },
     "require-dev": {
         "doctrine/doctrine-bundle": "^2.10",


### PR DESCRIPTION
The constraint "^0.2.2" does not update to version 0.3. In this repo and in my project using this repo.
I do not know why. But i know this issue from some other packages.

Maybe @kbond you have a better solution to fix it. But it works ;)

