### PR TITLE
feat: add check for LiipMonitoring-Bundle (WIP)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "doctrine/doctrine-bundle": "^2.10",
         "doctrine/orm": "^2.15",
         "knplabs/knp-time-bundle": "^1.20|^2.0",
-        "liip/monitor-bundle": "3.x-dev",
+        "liip/monitor-bundle": "^3.0",
         "lorisleiva/cron-translator": "^0.4.3",
         "matthiasnoback/symfony-dependency-injection-test": "^4.3|^5.0",
         "phpstan/phpstan": "^1.4",

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "doctrine/doctrine-bundle": "^2.10",
         "doctrine/orm": "^2.15",
         "knplabs/knp-time-bundle": "^1.20|^2.0",
-        "liip/monitor-bundle": "dev-feat/ohdear",
+        "liip/monitor-bundle": "3.x-dev",
         "lorisleiva/cron-translator": "^0.4.3",
         "matthiasnoback/symfony-dependency-injection-test": "^4.3|^5.0",
         "phpstan/phpstan": "^1.4",
@@ -55,11 +55,5 @@
         "psr-4": { "Zenstruck\\Messenger\\Monitor\\Tests\\": ["tests/"] }
     },
     "minimum-stability": "dev",
-    "prefer-stable": true,
-    "repositories": {
-        "liip/LiipMonitorBundle": {
-            "type": "vcs",
-            "url": "git@github.com:Chris53897/LiipMonitorBundle.git"
-        }
-    }
+    "prefer-stable": true
 }

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "doctrine/doctrine-bundle": "^2.10",
         "doctrine/orm": "^2.15",
         "knplabs/knp-time-bundle": "^1.20|^2.0",
+        "liip/monitor-bundle": "dev-feat/ohdear",
         "lorisleiva/cron-translator": "^0.4.3",
         "matthiasnoback/symfony-dependency-injection-test": "^4.3|^5.0",
         "phpstan/phpstan": "^1.4",
@@ -54,5 +55,11 @@
         "psr-4": { "Zenstruck\\Messenger\\Monitor\\Tests\\": ["tests/"] }
     },
     "minimum-stability": "dev",
-    "prefer-stable": true
+    "prefer-stable": true,
+    "repositories": {
+        "liip/LiipMonitorBundle": {
+            "type": "vcs",
+            "url": "git@github.com:Chris53897/LiipMonitorBundle.git"
+        }
+    }
 }

--- a/config/services.php
+++ b/config/services.php
@@ -11,6 +11,7 @@ use Zenstruck\Messenger\Monitor\Twig\ViewHelper;
 use Zenstruck\Messenger\Monitor\Worker\WorkerCache;
 use Zenstruck\Messenger\Monitor\Worker\WorkerListener;
 use Zenstruck\Messenger\Monitor\Workers;
+use Zenstruck\Messenger\Monitor\Check\WorkerRunningCheck;
 
 return static function (ContainerConfigurator $container): void {
     $container->services()
@@ -57,5 +58,11 @@ return static function (ContainerConfigurator $container): void {
                 service('time.datetime_formatter')->nullOnInvalid(),
             ])
             ->alias(ViewHelper::class, 'zenstruck_messenger_monitor.view_helper')
+
+        ->set('zenstruck_messenger_monitor.worker_running_check', WorkerRunningCheck::class)
+            ->args([
+                service('.zenstruck_messenger_monitor.worker_cache'),
+            ])
+            ->alias(WorkerRunningCheck::class, 'zenstruck_messenger_monitor.worker_running_check')
     ;
 };

--- a/src/Check/WorkerRunningCheck.php
+++ b/src/Check/WorkerRunningCheck.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/messenger-monitor-bundle package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Messenger\Monitor\Check;
+
+use Liip\Monitor\Check;
+use Liip\Monitor\Result;
+use Zenstruck\Messenger\Monitor\Worker\WorkerCache;
+use Liip\Monitor\AsCheck;
+
+#[AsCheck(id: 'symfony_worker_running', suite: 'messenger-monitoring')]
+class WorkerRunningCheck implements Check, \Stringable
+{
+    public function __construct(private WorkerCache $workerCache)
+    {}
+
+    public function __toString(): string
+    {
+        return 'symfony_worker_running';
+        #return 'Symfony Workers running';
+    }
+
+    public function run(): Result
+    {
+
+        #$this->workerCache->getIterator();
+
+        /*
+        if ($this->version->isEol()) {
+            return Result::failure(
+                \sprintf('%s - the %s branch is EOL', $this->version->currentVersion(), $this->version->branch()),
+                context: ['eol_date' => $this->version->supportUntil()]
+            );
+        }
+
+        if ($this->version->isPatchUpdateRequired()) {
+            return Result::warning(
+                \sprintf('%s - requires a patch update to %s', $this->version->currentVersion(), $this->version->latestPatchVersion()),
+                context: ['latest_patch_version' => $this->version->latestPatchVersion()]
+            );
+        }*/
+
+        return Result::success("Actual running: ". 2);
+    }
+
+    public static function configInfo(): ?string
+    {
+        return 'check if the minimum amount of symfony workers is running';
+    }
+
+    protected function detail(): string
+    {
+        return 'Details';
+        #return \sprintf('Disk (%s) is %s used (%s of %s total)', $this->path, $storage->percentUsed(), $storage->used(), $storage->total());
+    }
+
+    /*
+    public static function load(array $config, ContainerBuilder $container): void
+    {
+        if (!$config['enabled']) {
+            return;
+        }
+
+        var_dump("AAAAA");
+
+        $container->register(\sprintf('.liip_monitor.check.%s', static::configKey()), static::class)
+            ->setArguments([
+                new Reference('liip_monitor.info.symfony_worker_running'),
+            ])
+            ->addTag('liip_monitor.check', $config);
+    }*/
+}
+
+


### PR DESCRIPTION
i try to add checks for LiipMonitoring-Bundle
https://github.com/zenstruck/messenger-monitor-bundle/issues/11

But i am a bit stucked here.

I followed the example from here https://github.com/kbond/LiipMonitorBundle/tree/feat/ohdear#custom-checks
and took this Check as example https://github.com/kbond/LiipMonitorBundle/blob/feat/ohdear/src/Check/Symfony/SymfonyVersionCheck.php

I thought i could activated it like this.

```
liip_monitor:
    checks:
        symfony_worker_running: true
```

And see it with `php bin/console monitor:list`

But i will get an error, that  `symfony_worker_running` is not registered unter `checks`.

@kbond Maybe you can give me a little push to the right direction?
