### PR TITLE
[FTR] Add configurable cache 

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,4 +277,8 @@ zenstruck_messenger_monitor:
 
             # Your Doctrine entity class that extends "Zenstruck\Messenger\Monitor\History\Model\ProcessedMessage"
             entity_class:         ~
+    cache:
+      pool: app.cache # If using workers in docker. You can use shared cache pool for all workers
+      expired_worker_ttl:  3600
+
 ```

--- a/src/DependencyInjection/ZenstruckMessengerMonitorExtension.php
+++ b/src/DependencyInjection/ZenstruckMessengerMonitorExtension.php
@@ -87,6 +87,11 @@ final class ZenstruckMessengerMonitorExtension extends ConfigurableExtension imp
         $loader = new PhpFileLoader($container, new FileLocator(__DIR__.'/../../config'));
         $loader->load('services.php');
 
+        $cache = new Reference($mergedConfig['cache']['pool'], ContainerBuilder::NULL_ON_INVALID_REFERENCE);
+        if($cache === null) {
+            throw new LogicException(\sprintf('Cache pool "%s" not found.', $mergedConfig['cache']['pool']));
+        }
+
         $container->getDefinition('.zenstruck_messenger_monitor.worker_cache')
             ->setArgument(0, new Reference($mergedConfig['cache']['pool']))
             ->setArgument(1, $mergedConfig['cache']['expired_worker_ttl']);

--- a/src/DependencyInjection/ZenstruckMessengerMonitorExtension.php
+++ b/src/DependencyInjection/ZenstruckMessengerMonitorExtension.php
@@ -61,6 +61,7 @@ final class ZenstruckMessengerMonitorExtension extends ConfigurableExtension imp
                     ->end()
                 ->end()
                 ->arrayNode('cache')
+                    ->addDefaultsIfNotSet()
                     ->children()
                         ->scalarNode('pool')
                             ->info('Cache pool to use for worker cache.')
@@ -69,6 +70,7 @@ final class ZenstruckMessengerMonitorExtension extends ConfigurableExtension imp
                         ->integerNode('expired_worker_ttl')
                             ->info('How long to keep expired workers in cache (in seconds).')
                             ->defaultValue(3600)
+                        ->end()
                     ->end()
                 ->end()
             ->end()
@@ -86,11 +88,6 @@ final class ZenstruckMessengerMonitorExtension extends ConfigurableExtension imp
     {
         $loader = new PhpFileLoader($container, new FileLocator(__DIR__.'/../../config'));
         $loader->load('services.php');
-
-        $cache = new Reference($mergedConfig['cache']['pool'], ContainerBuilder::NULL_ON_INVALID_REFERENCE);
-        if($cache === null) {
-            throw new LogicException(\sprintf('Cache pool "%s" not found.', $mergedConfig['cache']['pool']));
-        }
 
         $container->getDefinition('.zenstruck_messenger_monitor.worker_cache')
             ->setArgument(0, new Reference($mergedConfig['cache']['pool']))

--- a/tests/DependencyInjection/ZenstruckMessengerMonitorExtensionTest.php
+++ b/tests/DependencyInjection/ZenstruckMessengerMonitorExtensionTest.php
@@ -74,6 +74,19 @@ final class ZenstruckMessengerMonitorExtensionTest extends AbstractExtensionTest
         $this->load(['storage' => ['orm' => ['entity_class' => ProcessedMessage::class]]]);
     }
 
+    /**
+     * @test
+     */
+    public function cache_config(): void
+    {
+        $this->load(['cache' => ['pool' => 'cache.app', 'expired_worker_ttl' => 7200]]);
+
+        $workerCacheDefinition = $this->container->getDefinition('.zenstruck_messenger_monitor.worker_cache');
+
+        $this->assertEquals('cache.app', (string) $workerCacheDefinition->getArgument(0));
+        $this->assertEquals(7200, $workerCacheDefinition->getArgument(1));
+    }
+
     protected function getContainerExtensions(): array
     {
         return [new ZenstruckMessengerMonitorExtension()];


### PR DESCRIPTION
This will add a configurable cache. 
It is usable in situations when workers do not have the same cache with the app.

For example, if each worker is a separate docker container with its own `/var` directory.
In such a situation, you need a shared cache (ideally own cache pool only for workers).