### PR TITLE
chore: fix ci action for "php-test-symfony"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           - php: 8.3
             symfony: '7.0.*'
     steps:
-      - uses: zenstruck/.github@php-test-symfony
+      - uses: zenstruck/.github/actions/php-test-symfony@main
         with:
           php: ${{ matrix.php }}
           symfony: ${{ matrix.symfony }}


### PR DESCRIPTION
Like suggested in the ci run.

```Run zenstruck/.github@php-test-symfony

Run echo ::warning::This action is deprecated, use the zenstruck/.github/actions/php-test-symfony@main action instead.

Warning: This action is deprecated, use the zenstruck/.github/actions/php-test-symfony@main action instead.
```