### PR TITLE
feat: Add message type filter in History

### DIFF
--- a/src/Controller/MessengerMonitorController.php
+++ b/src/Controller/MessengerMonitorController.php
@@ -81,6 +81,7 @@ abstract class MessengerMonitorController extends AbstractController
             'periods' => [...Period::inLastCases(), ...Period::absoluteCases()],
             'period' => $period,
             'snapshot' => $specification->snapshot($helper->storage),
+            'filters' => $specification->filters($helper->storage),
         ]);
     }
 

--- a/src/History/Filters.php
+++ b/src/History/Filters.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the zenstruck/messenger-monitor-bundle package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Messenger\Monitor\History;
+
+use Zenstruck\Collection;
+
+final class Filters
+{
+    /** @var Collection<int, string> */
+    private Collection $availableMessageTypes;
+
+    public function __construct(private readonly Storage $storage, private readonly Specification $specification)
+    {
+    }
+
+    /** @return Collection<int, string> */
+    public function availableMessageTypes(): Collection
+    {
+        return $this->availableMessageTypes ??= $this->storage->availableMessageTypes($this->specification)->eager();
+    }
+}

--- a/src/History/Specification.php
+++ b/src/History/Specification.php
@@ -188,6 +188,14 @@ final class Specification
         return $clone;
     }
 
+    public function ignoreMessageType(): self
+    {
+        $clone = clone $this;
+        $clone->messageType = null;
+
+        return $clone;
+    }
+
     /**
      * @return array{
      *     from: ?\DateTimeImmutable,
@@ -219,6 +227,11 @@ final class Specification
     public function snapshot(Storage $storage): Snapshot
     {
         return new Snapshot($storage, $this);
+    }
+
+    public function filters(Storage $storage): Filters
+    {
+        return new Filters($storage, $this);
     }
 
     private static function parseDate(string|\DateTimeImmutable|null $value): ?\DateTimeImmutable

--- a/src/History/Storage.php
+++ b/src/History/Storage.php
@@ -39,4 +39,9 @@ interface Storage
     public function averageHandlingTime(Specification $specification): ?float;
 
     public function count(Specification $specification): int;
+
+    /**
+     * @return Collection<int,string>
+     */
+    public function availableMessageTypes(Specification $specification): Collection;
 }

--- a/src/History/Storage/ORMStorage.php
+++ b/src/History/Storage/ORMStorage.php
@@ -80,6 +80,16 @@ final class ORMStorage implements Storage
         $om->flush();
     }
 
+    public function availableMessageTypes(Specification $specification): Collection
+    {
+        $qb = $this->queryBuilderFor($specification->ignoreMessageType(), false)
+            ->select('DISTINCT m.type')
+            ->orderBy('m.type', 'ASC')
+        ;
+
+        return (new EntityResult($qb))->asString();
+    }
+
     public function averageWaitTime(Specification $specification): ?float
     {
         $qb = $this

--- a/templates/history.html.twig
+++ b/templates/history.html.twig
@@ -74,17 +74,28 @@
                 </div>
             {% endif %}
 
-            {% if app.request.query.get('type') %}
-                <div class="btn-group me-2" role="group">
-                    <a title="{{ app.request.query.get('type') }}" href="{{ path(app.current_route, app.request.query.all|merge({type: null})) }}" class="btn btn-outline-primary">
-                        <small class="text-body-secondary">Message Type:</small>
-                        <span class="me-2">{{ app.request.query.get('type')|split('\\')|last }}</span>
-                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="align-text-bottom" viewBox="0 0 16 16">
-                            <path d="M4.646 4.646a.5.5 0 0 1 .708 0L8 7.293l2.646-2.647a.5.5 0 0 1 .708.708L8.707 8l2.647 2.646a.5.5 0 0 1-.708.708L8 8.707l-2.646 2.647a.5.5 0 0 1-.708-.708L7.293 8 4.646 5.354a.5.5 0 0 1 0-.708z"/>
-                        </svg>
-                    </a>
-                </div>
-            {% endif %}
+            <div class="btn-group me-2" role="group">
+                {% set current_type = app.request.query.get('type', 'All') %}
+                <button type="button" class="btn {{ current_type != 'All' ? 'btn-outline-primary' : 'btn-light' }} dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">
+                    <small class="text-body-secondary">Message type:</small> {{ current_type }}
+                </button>
+                <ul class="dropdown-menu">
+                    {% if 'All' != current_type %}
+                        <li><a class="dropdown-item" href="{{ path(app.current_route, app.request.query.all|merge({type: null})) }}">All</a></li>
+                    {% endif %}
+
+                    {% for type in filters.availableMessageTypes %}
+                        {% if type != current_type %}
+                            <li><a class="dropdown-item" href="{{ path(app.current_route, app.request.query.all|merge({type: type})) }}">
+                                    {{ type | split('\\') | last }} <br>
+                                    <small class="text-secondary">{{ type }}</small>
+                                </a>
+                            </li>
+                        {% endif %}
+                    {% endfor %}
+                </ul>
+            </div>
+
             {% if app.request.query.get('tag') %}
                 <div class="btn-group me-2" role="group">
                     <a href="{{ path(app.current_route, app.request.query.all|merge({tag: null})) }}" class="btn btn-outline-primary">


### PR DESCRIPTION
The History module now offers a handy message type filter. This new feature includes the implementation of a method in Storage that retrieves distinct message types. 

The filter feature considers other filters and ensures that the available types fall within the scope of the selected filter.
For instance, if you choose to filter messages for the past day, the Message type dropdown will only display the types that are relevant for that time period.

![image](https://github.com/zenstruck/messenger-monitor-bundle/assets/1829574/c22a2ac2-0fe9-4696-be7c-1acff6323b4a)

![image](https://github.com/zenstruck/messenger-monitor-bundle/assets/1829574/1e62fd85-6665-41b7-9ffa-50323b9a784a)

