### PR TITLE
fix: statistics for history

### DIFF
--- a/src/History/Storage/ORMStorage.php
+++ b/src/History/Storage/ORMStorage.php
@@ -91,7 +91,7 @@ final class ORMStorage implements Storage
     public function averageWaitTime(Specification $specification): ?float
     {
         $qb = $this
-            ->queryBuilderFor($specification)
+            ->queryBuilderFor($specification, false)
             ->select('AVG(m.receivedAt - m.dispatchedAt)')
         ;
 
@@ -101,7 +101,7 @@ final class ORMStorage implements Storage
     public function averageHandlingTime(Specification $specification): ?float
     {
         $qb = $this
-            ->queryBuilderFor($specification)
+            ->queryBuilderFor($specification, false)
             ->select('AVG(m.finishedAt - m.receivedAt)')
         ;
 
@@ -111,7 +111,7 @@ final class ORMStorage implements Storage
     public function count(Specification $specification): int
     {
         $qb = $this
-            ->queryBuilderFor($specification)
+            ->queryBuilderFor($specification, false)
             ->select('COUNT(m.finishedAt)')
         ;
 


### PR DESCRIPTION
#84 does not work under postgres.

I guess the reason the GroupBy was added in the first place, is because of the order-Clause.
If the Sepecifiation is ordered, Postgres demands a GroupBy clause and raises an error.

The order-clause is not relevant for the aggregated data. As long as there is no Limit specified.

@bobvandevijver Could you please test this change with MySQL?