### PR TITLE
fix: normalize_process_exception() test

### DIFF
--- a/tests/History/ResultNormalizerTest.php
+++ b/tests/History/ResultNormalizerTest.php
@@ -150,9 +150,10 @@ final class ResultNormalizerTest extends TestCase
             $this->assertSame(127, $result['exit_code']);
             $this->assertSame('', $result['output']);
 
-            # macOS does have this output (but not on ci)
-            if($result['error_output']!=='')
-            {$this->assertStringContainsString('exec: invalid: not found', $result['error_output']);}
+            // macOS does have this output (but not on ci)
+            if($result['error_output']!=='') {
+                $this->assertStringContainsString('exec: invalid: not found', $result['error_output']);
+            }
 
             return;
         }

--- a/tests/History/ResultNormalizerTest.php
+++ b/tests/History/ResultNormalizerTest.php
@@ -149,7 +149,10 @@ final class ResultNormalizerTest extends TestCase
             $this->assertStringContainsString(__FUNCTION__, $result['stack_trace']);
             $this->assertSame(127, $result['exit_code']);
             $this->assertSame('', $result['output']);
-            $this->assertStringContainsString('exec: invalid: not found', $result['error_output']);
+
+            # macOS does have this output (but not on ci)
+            if($result['error_output']!=='')
+            {$this->assertStringContainsString('exec: invalid: not found', $result['error_output']);}
 
             return;
         }


### PR DESCRIPTION
i am not sure why $result['error_output'] is emtpy now in the ci runs, and was not before.
Changes in symfony?