### PR TITLE
chore: ignore PHPStan errors for PHP 8.1

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,11 @@
 parameters:
     level: 8
     treatPhpDocTypesAsCertain: false
+    reportUnmatchedIgnoredErrors: false
     paths:
         - src
+
+    ignoreErrors:
+        # Can be dropped after minimum PHP Version is 8.2 or 8.3
+        - message: '#Cannot access offset [a-zA-Z] on array\|bool\|float\|int\|string\|UnitEnum#'
+          path: src/DependencyInjection/ZenstruckMessengerMonitorExtension.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,5 +7,5 @@ parameters:
 
     ignoreErrors:
         # Can be dropped after minimum PHP Version is 8.2 or 8.3
-        - message: '#Cannot access offset [a-zA-Z] on array\|bool\|float\|int\|string\|UnitEnum#'
+        - message: '#Cannot access offset [a-zA-Z]+ on array\|bool\|float\|int\|string\|UnitEnum.#'
           path: src/DependencyInjection/ZenstruckMessengerMonitorExtension.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,5 +7,5 @@ parameters:
 
     ignoreErrors:
         # Can be dropped after minimum PHP Version is 8.2 or 8.3
-        - message: '#Cannot access offset [a-zA-Z]+ on array\|bool\|float\|int\|string\|UnitEnum.#'
+        - message: '#Cannot access offset ''LiveComponentBundle'' on array\|bool\|float\|int\|string\|UnitEnum.#'
           path: src/DependencyInjection/ZenstruckMessengerMonitorExtension.php


### PR DESCRIPTION
The error in the ci is raising on PHP 8.1.
It is not there on PHP 8.3.   8.2?