### PR TITLE
feat: change label to danger for failed transport

### DIFF
--- a/templates/transport.html.twig
+++ b/templates/transport.html.twig
@@ -17,7 +17,7 @@
                 {% for item in transports %}
                     <li class="nav-item position-relative mx-2" role="presentation">
                         {% if item|length %}
-                            <span class="z-2 position-absolute top-0 start-100 translate-middle badge rounded-pill bg-primary">
+                            <span class="z-2 position-absolute top-0 start-100 translate-middle badge rounded-pill {{ item.isFailure ? 'bg-danger' : 'bg-primary' }}">
                                 {{ item|length }} <span class="visually-hidden">queued messages</span>
                             </span>
                         {% else %}


### PR DESCRIPTION
Fixes https://github.com/zenstruck/messenger-monitor-bundle/issues/85

The Label is set to danger if > 0 messages

After:
<img width="744" alt="after" src="https://github.com/zenstruck/messenger-monitor-bundle/assets/7104259/8752d3ab-3d41-4a60-9046-7e99a79eda89">
