### PR TITLE
ci: add testrun for PHP 8.4 and symfony 7.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [ 8.1, 8.2, 8.3 ]
+        php: [ 8.1, 8.2, 8.3, 8.4 ]
         deps: [ highest ]
         symfony: [ 6.4.* ]
         include:
@@ -21,6 +21,9 @@ jobs:
             symfony: '*'
           - php: 8.3
             symfony: '7.0.*'
+          - php: 8.4
+            symfony: '7.1.*'
+
     steps:
       - uses: zenstruck/.github/actions/php-test-symfony@main
         with:
@@ -37,6 +40,16 @@ jobs:
   sca:
     uses: zenstruck/.github/.github/workflows/php-stan.yml@main
 
+  sync-with-template:
+    name: Sync meta files
+    if: (github.event_name == 'push' || github.event_name == 'schedule') && !startsWith(github.ref, 'refs/tags') && github.repository_owner == 'zenstruck'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: zenstruck/.github@sync-with-template
+        with:
+          key: ${{ secrets.GPG_PRIVATE_KEY }}
+          token: ${{ secrets.COMPOSER_TOKEN }}
+
   fixcs:
     name: Run php-cs-fixer
     needs: sync-with-template
@@ -46,15 +59,5 @@ jobs:
       - uses: zenstruck/.github@php-cs-fixer
         with:
           php: 8.1
-          key: ${{ secrets.GPG_PRIVATE_KEY }}
-          token: ${{ secrets.COMPOSER_TOKEN }}
-
-  sync-with-template:
-    name: Sync meta files
-    if: (github.event_name == 'push' || github.event_name == 'schedule') && !startsWith(github.ref, 'refs/tags') && github.repository_owner == 'zenstruck'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: zenstruck/.github@sync-with-template
-        with:
           key: ${{ secrets.GPG_PRIVATE_KEY }}
           token: ${{ secrets.COMPOSER_TOKEN }}


### PR DESCRIPTION
PhpStorm shows a warning about the order of  the dependent steps.
So i changed them. I think it is better readable now. But of course i can revert that.