### PR TITLE
doc: add notes about CSRF and Form requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,11 @@ bin/console messenger:monitor:schedule:purge --remove-orphans
 ## User Interface
 
 > [!NOTE]
-> `symfony/form` and `symfony/security-csrf` (`composer require symfony/form symfony/security-csrf`) are required for the UI.
+> `symfony/form` (`composer require symfony/form`) is required for the UI.
+
+> [!NOTE]
+> If using `symfony/scheduler` and the UI, `symfony/security-csrf` (`composer require symfony/security-csrf`) is required.
+> CSRF protection and sessions must also be enabled in your `config/packages/framework.yaml`.
 
 > [!NOTE]
 > [Storage](#storage) must be configured for this feature.

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ bin/console messenger:monitor:schedule:purge --remove-orphans
 ## User Interface
 
 > [!NOTE]
-> `symfony/form` (`composer require symfony/form`) is required for the UI.
+> `symfony/form` and `symfony/security-csrf` (`composer require symfony/form symfony/security-csrf`) are required for the UI.
 
 > [!NOTE]
 > [Storage](#storage) must be configured for this feature.

--- a/README.md
+++ b/README.md
@@ -202,6 +202,9 @@ bin/console messenger:monitor:schedule:purge --remove-orphans
 ## User Interface
 
 > [!NOTE]
+> `symfony/form` (`composer require symfony/form`) is required for the UI.
+
+> [!NOTE]
 > [Storage](#storage) must be configured for this feature.
 
 Create a controller that extends `Zenstruck\Messenger\Monitor\Controller\MessengerMonitorController`
@@ -239,10 +242,6 @@ You can now access the dashboard at: `/admin/messenger` or with the route `zenst
 > [!NOTE]
 > Install `lorisleiva/cron-translator` (`composer require lorisleiva/cron-translator`) to display
 > friendlier CRON values for your scheduled tasks.
-
-> [!NOTE]
-> Install `symfony/form` (`composer require symfony/form`) for the CSRF support when doing Ajax calls.
-> Necessary if when using symfony/scheduler is used.
 
 ## Advanced Usage
 

--- a/README.md
+++ b/README.md
@@ -240,6 +240,10 @@ You can now access the dashboard at: `/admin/messenger` or with the route `zenst
 > Install `lorisleiva/cron-translator` (`composer require lorisleiva/cron-translator`) to display
 > friendlier CRON values for your scheduled tasks.
 
+> [!NOTE]
+> Install `symfony/form` (`composer require symfony/form`) for the CSRF support when doing Ajax calls.
+> Necessary if when using symfony/scheduler is used.
+
 ## Advanced Usage
 
 ### `Workers` Service

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,8 @@
     "suggest": {
         "knplabs/knp-time-bundle": "For human readable timestamps and durations on your dashboard.",
         "lorisleiva/cron-translator": "For human readable cron expressions on your dashboard.",
-        "symfony/ux-live-component": "For Live Components"
+        "symfony/ux-live-component": "For Live Components",
+        "symfony/form": "For CSRF token used in Ajax calls when using symfony/scheduler"
     },
     "config": {
         "preferred-install": "dist",

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,8 @@
         "knplabs/knp-time-bundle": "For human readable timestamps and durations on your dashboard.",
         "lorisleiva/cron-translator": "For human readable cron expressions on your dashboard.",
         "symfony/ux-live-component": "For Live Components",
-        "symfony/form": "For CSRF token used in Ajax calls when using symfony/scheduler"
+        "symfony/form": "For the UI",
+        "symfony/security-csrf": "For CSRF token used in UI Ajax calls"
     },
     "config": {
         "preferred-install": "dist",

--- a/templates/schedule.html.twig
+++ b/templates/schedule.html.twig
@@ -27,7 +27,7 @@
                         {% endif %}
 
                         <a href="{{ path('zenstruck_messenger_monitor_schedule', {name: item.name}) }}" class="nav-link{{ item.name == schedule.name ? ' active' }}">
-                            {{ item.name }} Schedule
+                            {{ item.name|humanize }} Schedule
                         </a>
                     </li>
                 {% endfor %}

--- a/templates/schedule.html.twig
+++ b/templates/schedule.html.twig
@@ -27,7 +27,7 @@
                         {% endif %}
 
                         <a href="{{ path('zenstruck_messenger_monitor_schedule', {name: item.name}) }}" class="nav-link{{ item.name == schedule.name ? ' active' }}">
-                            {{ item.name|humanize }} Schedule
+                            {{ item.name }} Schedule
                         </a>
                     </li>
                 {% endfor %}


### PR DESCRIPTION
`humanize` twig filter is used to display a human readable scheduler names. The filter uses `FormRenderer` which is available in `symfony/form`. Should the bundle drop the use of humanize? It seems too small benefit to add such a big dependency, especially for API or console projects.

Error:
> Uncaught PHP Exception Twig\Error\SyntaxError: "Did you forget to run "composer require symfony/form"? Unknown filter "humanize" in "@ZenstruckMessengerMonitor/schedule.html.twig"." at UndefinedCallableHandler.php line 99
