### PR TITLE
[RFC] feat: allow retrying failed messages

### DIFF
--- a/templates/transport.html.twig
+++ b/templates/transport.html.twig
@@ -96,11 +96,17 @@
                                             {% endif %}
                                         </td>
                                     {% endif %}
-                                    <td>
+                                    <td class="text-end">
                                         <a href="{{ path('zenstruck_messenger_monitor_transport_remove', {name: transport.name, id: queued.id}) }}" class="post-link btn btn-sm btn-outline-danger" data-confirm="Are you sure?" data-token="{{ csrf_token(['remove', queued.id, transport.name]|join('-')) }}">
                                             <svg fill="currentcolor" height="1em" width="1em" class="me-1 align-text-bottom" role="img" aria-label="Info:"><use xlink:href="#trash-icon"/></svg>
                                             Remove
                                         </a>
+                                        {% if transport.isFailure %}
+                                            <a href="{{ path('zenstruck_messenger_monitor_transport_retry', {name: transport.name, id: queued.id}) }}" class="post-link btn btn-sm btn-outline-secondary" data-token="{{ csrf_token(['retry', queued.id, transport.name]|join('-')) }}">
+                                                <svg fill="currentcolor" height="1em" width="1em" class="me-1 align-text-bottom" role="img" aria-label="Info:"><use xlink:href="#refresh-icon"/></svg>
+                                                Retry
+                                            </a>
+                                        {% endif %}
                                     </td>
                                 </tr>
                             {% endfor %}

--- a/templates/transport.html.twig
+++ b/templates/transport.html.twig
@@ -90,7 +90,8 @@
                                     {% if transport.isFailure %}
                                         <td>
                                             {% if queued.exception %}
-                                                <strong class="text-danger"><abbr title="{{ queued.exception }}">{{ queued.exception.shortName }}</abbr>: {{ queued.exception.description }}</strong>
+                                                <strong class="text-danger"><abbr title="{{ queued.exception }}">{{ queued.exception.shortName }}</abbr></strong>
+                                                <br><small class="text-secondary">{{ queued.exception.description }}</small>
                                             {% else %}
                                                 <em class="text-secondary">n/a</em>
                                             {% endif %}


### PR DESCRIPTION
Fixes #15.

(Depends on #102)

<img width="1176" alt="Screenshot 2024-11-11 at 10 04 52 PM" src="https://github.com/user-attachments/assets/1041054b-ed11-4038-8ec7-0e2b764e5ffd">

Adds a button to retry a failed message. I chose not to use the failure transport to retry as I didn't want to block the request. So I send it back to the original transport allowing it to be retried asynchronously. This _does_ trigger the original retries again on another failure whereas `bin/console messenger:failed:retry` tries again just once and drops. When the retries are used up it is not sent back to the failure transport a second time.

I'm not 100% certain this is without edge-cases I'm not seeing so if anyone has any feedback, I'd appreciate it!