### PR TITLE
feat!: add wait/handle time to `ProcessedMessage`

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,42 @@
+# Upgrade Guide
+
+## 0.5.0
+
+Two new `integer` columns were added to the `processed_messages` table:
+`wait_time` and `handle_time`. You will need to create a migration to
+add these columns to your database. They are not nullable so your
+migration will need to account for existing data. You can either
+truncate (purge) the `processed_messages` table have your migration
+calculate these values based on the existing data.
+
+Here's a calculation example for MySQL:
+
+```php
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class VersionXXX extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add processed_messages.wait_time and handle_time columns';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // Add the columns as nullable
+        $this->addSql('ALTER TABLE processed_messages ADD wait_time INT DEFAULT NULL, ADD handle_time INT DEFAULT NULL');
+
+        // set the times from existing data
+        $this->addSql('UPDATE processed_messages SET wait_time = TIMESTAMPDIFF(SECOND, dispatched_at, received_at), handle_time = TIMESTAMPDIFF(SECOND, received_at, finished_at)');
+
+        // Make the columns not nullable
+        $this->addSql('ALTER TABLE processed_messages CHANGE wait_time wait_time INT NOT NULL, CHANGE handle_time handle_time INT NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE processed_messages DROP wait_time, DROP handle_time');
+    }
+}
+```

--- a/config/doctrine/mapping/ProcessedMessage.orm.xml
+++ b/config/doctrine/mapping/ProcessedMessage.orm.xml
@@ -11,6 +11,8 @@
         <field name="dispatchedAt" column="dispatched_at" type="datetime_immutable" />
         <field name="receivedAt" column="received_at" type="datetime_immutable" />
         <field name="finishedAt" column="finished_at" type="datetime_immutable" />
+        <field name="waitTime" column="wait_time" type="integer" />
+        <field name="handleTime" column="handle_time" type="integer" />
         <field name="memoryUsage" column="memory_usage" type="integer" />
         <field name="transport" column="transport" />
         <field name="tags" column="tags" nullable="true" />

--- a/src/History/Storage/ORMStorage.php
+++ b/src/History/Storage/ORMStorage.php
@@ -92,7 +92,7 @@ final class ORMStorage implements Storage
     {
         $qb = $this
             ->queryBuilderFor($specification, false)
-            ->select('AVG(m.receivedAt - m.dispatchedAt)')
+            ->select('AVG(m.waitTime)')
         ;
 
         return (new EntityResult($qb))->asFloat()->first();
@@ -102,7 +102,7 @@ final class ORMStorage implements Storage
     {
         $qb = $this
             ->queryBuilderFor($specification, false)
-            ->select('AVG(m.finishedAt - m.receivedAt)')
+            ->select('AVG(m.handleTime)')
         ;
 
         return (new EntityResult($qb))->asFloat()->first();

--- a/tests/Fixture/Factory/ProcessedMessageFactory.php
+++ b/tests/Fixture/Factory/ProcessedMessageFactory.php
@@ -29,6 +29,17 @@ final class ProcessedMessageFactory extends PersistentObjectFactory
     {
         return parent::initialize()
             ->instantiateWith(Instantiator::withoutConstructor()->alwaysForce())
+            ->beforeInstantiate(function(array $attributes) {
+                if (!isset($attributes['waitTime'])) {
+                    $attributes['waitTime'] = \max(0, $attributes['receivedAt']->getTimestamp() - $attributes['dispatchedAt']->getTimestamp());
+                }
+
+                if (!isset($attributes['processingTime'])) {
+                    $attributes['handleTime'] = \max(0, $attributes['finishedAt']->getTimestamp() - $attributes['receivedAt']->getTimestamp());
+                }
+
+                return $attributes;
+            })
         ;
     }
 


### PR DESCRIPTION
Fixes #97.

This is a BC break and will require existing apps to create a migration. The migration would need to either clear the existing `ProcessedMessage`'s or calculate the values when adding the fields.

This isn't ideal but feels like the best way to eliminate the timestamp diff db logic that DB platforms all handle differently.

TODO:
- [x] `UPGRADE.md`