### PR TITLE
feat: limit number of queued messages shown

### DIFF
--- a/src/Controller/MessengerMonitorController.php
+++ b/src/Controller/MessengerMonitorController.php
@@ -129,7 +129,7 @@ abstract class MessengerMonitorController extends AbstractController
     #[Route('/transport/{name}', name: 'zenstruck_messenger_monitor_transport', defaults: ['name' => null])]
     public function transports(
         ViewHelper $helper,
-
+        Request $request,
         ?string $name = null,
     ): Response {
         $countable = $helper->transports->filter()->countable();
@@ -146,6 +146,7 @@ abstract class MessengerMonitorController extends AbstractController
             'helper' => $helper,
             'transports' => $countable,
             'transport' => $helper->transports->get($name),
+            'limit' => $request->query->getInt('limit', 50),
         ]);
     }
 

--- a/templates/transport.html.twig
+++ b/templates/transport.html.twig
@@ -49,6 +49,17 @@
                     </div>
                 </div>
             {% else %}
+                {% set queuedMessages = transport.list(limit) %}
+
+                {% if queuedMessages|length == limit %}
+                    <div class="card-alert card-text alert alert-warning d-flex align-items-center" role="alert">
+                        <svg fill="currentcolor" height="1em" width="1em" class="me-1 align-text-bottom" role="img" aria-label="Info:"><use xlink:href="#info-fill"/></svg>
+                        <div>
+                            Only showing the oldest {{ limit }} messages.
+                        </div>
+                    </div>
+                {% endif %}
+
                 <div class="table-responsive">
                     <table class="table card-table table-striped text-nowrap align-middle">
                         <thead>
@@ -63,7 +74,7 @@
                         </tr>
                         </thead>
                         <tbody>
-                            {% for queued in transport.list %}
+                            {% for queued in queuedMessages %}
                                 <tr>
                                     <td>
                                         <abbr title="{{ queued.message }}">{{ queued.message.shortName }}</abbr>


### PR DESCRIPTION
Fixes #33.

Default limit of 50 but can be customized with `?limit=n`.