### PR TITLE
More Features

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ or the [provided tools](#history).
 
 #### Disable Monitoring
 
-You may want to disable monitoring for certain messages. There are two ways to do this:
+You may want to disable monitoring for certain messages. There are several ways to do this:
 
 1. When dispatching the message, add the `DisableMonitoringStamp`:
     ```php
@@ -97,7 +97,7 @@ You may want to disable monitoring for certain messages. There are two ways to d
 
     $bus->dispatch(new MyMessage(), [new DisableMonitoringStamp()])
     ```
-2. Add the `DisableMonitoringStamp` as a class attribute to your message:
+2. Add the `DisableMonitoringStamp` as a class attribute to your message (or parent class):
     ```php
     use Zenstruck\Messenger\Monitor\Stamp\DisableMonitoringStamp;
 
@@ -106,8 +106,8 @@ You may want to disable monitoring for certain messages. There are two ways to d
     {
     }
     ```
-3. You may want to disable monitoring for messages that are dispatched without any handler.
-You can do this by using the `DisableMonitoringStamp` with optional constructor argument `true`:
+    You may want to disable monitoring for messages that are dispatched without any handler.
+    You can do this by using the `DisableMonitoringStamp` with optional constructor argument `true`:
     ```php
     use Zenstruck\Messenger\Monitor\Stamp\DisableMonitoringStamp;
 
@@ -115,6 +115,15 @@ You can do this by using the `DisableMonitoringStamp` with optional constructor 
     class MyMessage
     {
     }
+    ```
+3. Add the message class to the `exclude` config option (can be abstract/interface):
+    ```yaml
+    # config/packages/zenstruck_messenger_monitor.yaml
+
+    zenstruck_messenger_monitor:
+        storage:
+            exclude:
+                - App\Message\MyMessage
     ```
 
 #### Description
@@ -300,6 +309,8 @@ when@dev:
 ```yaml
 zenstruck_messenger_monitor:
     storage:
+        # Message classes to disable monitoring for (can be abstract/interface)
+        exclude:              []
         orm:
 
             # Your Doctrine entity class that extends "Zenstruck\Messenger\Monitor\History\Model\ProcessedMessage"

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ add your own in one of two ways:
 
     $bus->dispatch(new MyMessage(), [new TagStamp('tag-1'), new TagStamp('tag-2')])
     ```
-2. Add the `TagStamp` as a class attribute to your message:
+2. Add the `TagStamp` as a class attribute to your message (and parent class/interface):
     ```php
     use Zenstruck\Messenger\Monitor\Stamp\TagStamp;
 
@@ -164,6 +164,8 @@ add your own in one of two ways:
     {
     }
     ```
+    > [!TIP]
+    > You can also add the `TagStamp` attribute to parent classes/interfaces.
 
 #### `messenger:monitor:purge` Command
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ You may want to disable monitoring for certain messages. There are several ways 
 
     $bus->dispatch(new MyMessage(), [new DisableMonitoringStamp()])
     ```
-2. Add the `DisableMonitoringStamp` as a class attribute to your message (or parent class):
+2. Add the `DisableMonitoringStamp` as a class attribute to your message (or parent class/interface):
     ```php
     use Zenstruck\Messenger\Monitor\Stamp\DisableMonitoringStamp;
 

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,8 @@
         "symfony/serializer": "^6.4|^7.0",
         "symfony/var-dumper": "^6.4|^7.0",
         "zenstruck/console-test": "^1.5",
-        "zenstruck/foundry": "^2.2"
+        "zenstruck/foundry": "^2.2",
+        "zenstruck/messenger-test": "^1.11"
     },
     "suggest": {
         "knplabs/knp-time-bundle": "For human readable timestamps and durations on your dashboard.",

--- a/config/storage_orm.php
+++ b/config/storage_orm.php
@@ -33,6 +33,7 @@ return static function (ContainerConfigurator $container): void {
             ->args([
                 service('zenstruck_messenger_monitor.history.storage'),
                 service('.zenstruck_messenger_monitor.history.result_normalizer'),
+                abstract_arg('exclude_classes'),
             ])
             ->tag('kernel.event_listener', ['method' => 'addMonitorStamp', 'event' => SendMessageToTransportsEvent::class])
             ->tag('kernel.event_listener', ['method' => 'receiveMessage', 'event' => WorkerMessageReceivedEvent::class])

--- a/config/storage_orm.php
+++ b/config/storage_orm.php
@@ -8,7 +8,9 @@ use Symfony\Component\Messenger\Event\WorkerMessageHandledEvent;
 use Symfony\Component\Messenger\Event\WorkerMessageReceivedEvent;
 use Zenstruck\Messenger\Monitor\Command\PurgeCommand;
 use Zenstruck\Messenger\Monitor\Command\SchedulePurgeCommand;
-use Zenstruck\Messenger\Monitor\History\HistoryListener;
+use Zenstruck\Messenger\Monitor\EventListener\AddMonitorStampListener;
+use Zenstruck\Messenger\Monitor\EventListener\HandleMonitorStampListener;
+use Zenstruck\Messenger\Monitor\EventListener\ReceiveMonitorStampListener;
 use Zenstruck\Messenger\Monitor\History\ResultNormalizer;
 use Zenstruck\Messenger\Monitor\History\Storage;
 use Zenstruck\Messenger\Monitor\History\Storage\ORMStorage;
@@ -29,14 +31,20 @@ return static function (ContainerConfigurator $container): void {
         ->set('.zenstruck_messenger_monitor.history.result_normalizer', ResultNormalizer::class)
             ->args([param('kernel.project_dir')])
 
-        ->set('.zenstruck_messenger_monitor.history.listener', HistoryListener::class)
+        ->set('.zenstruck_messenger_monitor.listener.add_monitor_stamp', AddMonitorStampListener::class)
+            ->tag('kernel.event_listener', ['method' => '__invoke', 'event' => SendMessageToTransportsEvent::class])
+
+        ->set('.zenstruck_messenger_monitor.listener.receive_monitor_stamp', ReceiveMonitorStampListener::class)
+            ->args([
+                abstract_arg('exclude_classes')
+            ])
+            ->tag('kernel.event_listener', ['method' => '__invoke', 'event' => WorkerMessageReceivedEvent::class])
+
+        ->set('.zenstruck_messenger_monitor.listener.handle_monitor_stamp', HandleMonitorStampListener::class)
             ->args([
                 service('zenstruck_messenger_monitor.history.storage'),
                 service('.zenstruck_messenger_monitor.history.result_normalizer'),
-                abstract_arg('exclude_classes'),
             ])
-            ->tag('kernel.event_listener', ['method' => 'addMonitorStamp', 'event' => SendMessageToTransportsEvent::class])
-            ->tag('kernel.event_listener', ['method' => 'receiveMessage', 'event' => WorkerMessageReceivedEvent::class])
             ->tag('kernel.event_listener', ['method' => 'handleSuccess', 'event' => WorkerMessageHandledEvent::class])
             ->tag('kernel.event_listener', ['method' => 'handleFailure', 'event' => WorkerMessageFailedEvent::class])
 

--- a/src/DependencyInjection/ZenstruckMessengerMonitorExtension.php
+++ b/src/DependencyInjection/ZenstruckMessengerMonitorExtension.php
@@ -103,8 +103,8 @@ final class ZenstruckMessengerMonitorExtension extends ConfigurableExtension imp
             $container->getDefinition('zenstruck_messenger_monitor.history.storage')
                 ->setArgument(1, $entity)
             ;
-            $container->getDefinition('.zenstruck_messenger_monitor.history.listener')
-                ->setArgument(2, $mergedConfig['storage']['exclude'])
+            $container->getDefinition('.zenstruck_messenger_monitor.listener.receive_monitor_stamp')
+                ->setArgument(0, $mergedConfig['storage']['exclude'])
             ;
 
             if (!\class_exists(Schedule::class)) {

--- a/src/EventListener/AddMonitorStampListener.php
+++ b/src/EventListener/AddMonitorStampListener.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/messenger-monitor-bundle package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Messenger\Monitor\EventListener;
+
+use Symfony\Component\Messenger\Event\SendMessageToTransportsEvent;
+use Zenstruck\Messenger\Monitor\Stamp\MonitorStamp;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ *
+ * @internal
+ */
+final class AddMonitorStampListener
+{
+    public function __invoke(SendMessageToTransportsEvent $event): void
+    {
+        $event->setEnvelope($event->getEnvelope()->with(new MonitorStamp()));
+    }
+}

--- a/src/EventListener/ReceiveMonitorStampListener.php
+++ b/src/EventListener/ReceiveMonitorStampListener.php
@@ -65,9 +65,7 @@ final class ReceiveMonitorStampListener
             }
         }
 
-        $stamp = $envelope->last(DisableMonitoringStamp::class) ?? DisableMonitoringStamp::getFor($messageClass);
-
-        if (!$stamp) {
+        if (!$stamp = DisableMonitoringStamp::firstFrom($envelope)) {
             return false;
         }
 

--- a/src/EventListener/ReceiveMonitorStampListener.php
+++ b/src/EventListener/ReceiveMonitorStampListener.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/messenger-monitor-bundle package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Messenger\Monitor\EventListener;
+
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Event\WorkerMessageReceivedEvent;
+use Symfony\Component\Messenger\Stamp\HandledStamp;
+use Symfony\Component\Scheduler\Messenger\ScheduledStamp;
+use Zenstruck\Messenger\Monitor\Stamp\DisableMonitoringStamp;
+use Zenstruck\Messenger\Monitor\Stamp\MonitorStamp;
+use Zenstruck\Messenger\Monitor\Stamp\TagStamp;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ *
+ * @internal
+ */
+final class ReceiveMonitorStampListener
+{
+    /**
+     * @param class-string[] $excludedClasses
+     */
+    public function __construct(private array $excludedClasses)
+    {
+    }
+
+    public function __invoke(WorkerMessageReceivedEvent $event): void
+    {
+        $envelope = $event->getEnvelope();
+
+        if ($this->isMonitoringDisabled($envelope)) {
+            return;
+        }
+
+        $stamp = $envelope->last(MonitorStamp::class);
+
+        if (\class_exists(ScheduledStamp::class) && $scheduledStamp = $envelope->last(ScheduledStamp::class)) {
+            // scheduler transport doesn't trigger SendMessageToTransportsEvent
+            $stamp = new MonitorStamp($scheduledStamp->messageContext->triggeredAt);
+
+            $event->addStamps(TagStamp::forSchedule($scheduledStamp));
+        }
+
+        if ($stamp instanceof MonitorStamp) {
+            $event->addStamps($stamp->markReceived($event->getReceiverName()));
+        }
+    }
+
+    private function isMonitoringDisabled(Envelope $envelope): bool
+    {
+        $messageClass = $envelope->getMessage()::class;
+
+        foreach ($this->excludedClasses as $excludedClass) {
+            if (\is_a($messageClass, $excludedClass, true)) {
+                return true;
+            }
+        }
+
+        $stamp = $envelope->last(DisableMonitoringStamp::class) ?? DisableMonitoringStamp::getFor($messageClass);
+
+        if (!$stamp) {
+            return false;
+        }
+
+        if ($stamp->onlyWhenNoHandler && !$this->hasNoHandlers($envelope)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private function hasNoHandlers(Envelope $envelope): bool
+    {
+        return [] === $envelope->all(HandledStamp::class);
+    }
+}

--- a/src/History/Model/ProcessedMessage.php
+++ b/src/History/Model/ProcessedMessage.php
@@ -44,8 +44,8 @@ abstract class ProcessedMessage
     private ?string $failureType = null;
     private ?string $failureMessage = null;
 
-    /** @var Structure[]|Results */
-    private array|Results $results;
+    /** @var Structure[]|Results|null */
+    private array|Results|null $results;
 
     public function __construct(Envelope $envelope, Results $results, ?\Throwable $exception = null)
     {

--- a/src/History/Model/Results.php
+++ b/src/History/Model/Results.php
@@ -26,9 +26,9 @@ final class Results implements \Countable, \IteratorAggregate, \JsonSerializable
     /**
      * @internal
      *
-     * @param Structure[] $data
+     * @param Structure[]|null $data
      */
-    public function __construct(private array $data)
+    public function __construct(private ?array $data)
     {
     }
 
@@ -37,7 +37,7 @@ final class Results implements \Countable, \IteratorAggregate, \JsonSerializable
      */
     public function all(): array
     {
-        return $this->all ??= \array_map(static fn(array $result) => new Result($result), $this->data);
+        return $this->all ??= \array_map(static fn(array $result) => new Result($result), $this->data ?? []);
     }
 
     /**
@@ -63,13 +63,13 @@ final class Results implements \Countable, \IteratorAggregate, \JsonSerializable
 
     public function count(): int
     {
-        return \count($this->data);
+        return \count($this->all());
     }
 
     /**
-     * @return Structure[]
+     * @return Structure[]|null
      */
-    public function jsonSerialize(): array
+    public function jsonSerialize(): ?array
     {
         return $this->data;
     }

--- a/src/History/Model/Tags.php
+++ b/src/History/Model/Tags.php
@@ -100,12 +100,8 @@ final class Tags implements \IteratorAggregate, \Countable, \Stringable
      */
     private static function parseFrom(Envelope $envelope): \Traversable
     {
-        foreach ((new \ReflectionClass($envelope->getMessage()))->getAttributes(TagStamp::class) as $attribute) {
-            yield $attribute->newInstance()->value;
-        }
-
-        foreach ($envelope->all(TagStamp::class) as $tag) {
-            yield $tag->value; // @phpstan-ignore-line
+        foreach (TagStamp::from($envelope) as $tag) {
+            yield $tag->value;
         }
     }
 }

--- a/src/Stamp/AttributeStamp.php
+++ b/src/Stamp/AttributeStamp.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/messenger-monitor-bundle package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Messenger\Monitor\Stamp;
+
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Stamp\StampInterface;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+abstract class AttributeStamp implements StampInterface
+{
+    /**
+     * @internal
+     *
+     * @return static[]
+     */
+    final public static function from(Envelope $envelope): iterable
+    {
+        foreach ($envelope->all(static::class) as $stamp) {
+            yield $stamp; // @phpstan-ignore generator.valueType
+        }
+
+        $original = $reflection = new \ReflectionClass($envelope->getMessage());
+
+        while (false !== $reflection) {
+
+            foreach ($reflection->getAttributes(static::class) as $attribute) {
+                yield $attribute->newInstance();
+            }
+
+            $reflection = $reflection->getParentClass();
+        }
+
+        foreach ($original->getInterfaces() as $refInterface) {
+            foreach ($refInterface->getAttributes(static::class) as $attribute) {
+                yield $attribute->newInstance();
+            }
+        }
+    }
+
+    /**
+     * @internal
+     */
+    final public static function firstFrom(Envelope $envelope): ?static
+    {
+        foreach (self::from($envelope) as $stamp) {
+            return $stamp;
+        }
+
+        return null;
+    }
+}

--- a/src/Stamp/DisableMonitoringStamp.php
+++ b/src/Stamp/DisableMonitoringStamp.php
@@ -22,4 +22,30 @@ final class DisableMonitoringStamp implements StampInterface
     public function __construct(public readonly bool $onlyWhenNoHandler = false)
     {
     }
+
+    /**
+     * @internal
+     *
+     * @param class-string $class
+     */
+    public static function getFor(string $class): ?self
+    {
+        $original = $reflection = new \ReflectionClass($class);
+
+        while (false !== $reflection) {
+            if ($attributes = $reflection->getAttributes(self::class)) {
+                return $attributes[0]->newInstance();
+            }
+
+            $reflection = $reflection->getParentClass();
+        }
+
+        foreach ($original->getInterfaces() as $refInterface) {
+            if ($attributes = $refInterface->getAttributes(self::class)) {
+                return $attributes[0]->newInstance();
+            }
+        }
+
+        return null;
+    }
 }

--- a/src/Stamp/DisableMonitoringStamp.php
+++ b/src/Stamp/DisableMonitoringStamp.php
@@ -11,41 +11,13 @@
 
 namespace Zenstruck\Messenger\Monitor\Stamp;
 
-use Symfony\Component\Messenger\Stamp\StampInterface;
-
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  */
 #[\Attribute(\Attribute::TARGET_CLASS)]
-final class DisableMonitoringStamp implements StampInterface
+final class DisableMonitoringStamp extends AttributeStamp
 {
     public function __construct(public readonly bool $onlyWhenNoHandler = false)
     {
-    }
-
-    /**
-     * @internal
-     *
-     * @param class-string $class
-     */
-    public static function getFor(string $class): ?self
-    {
-        $original = $reflection = new \ReflectionClass($class);
-
-        while (false !== $reflection) {
-            if ($attributes = $reflection->getAttributes(self::class)) {
-                return $attributes[0]->newInstance();
-            }
-
-            $reflection = $reflection->getParentClass();
-        }
-
-        foreach ($original->getInterfaces() as $refInterface) {
-            if ($attributes = $refInterface->getAttributes(self::class)) {
-                return $attributes[0]->newInstance();
-            }
-        }
-
-        return null;
     }
 }

--- a/src/Stamp/TagStamp.php
+++ b/src/Stamp/TagStamp.php
@@ -11,7 +11,6 @@
 
 namespace Zenstruck\Messenger\Monitor\Stamp;
 
-use Symfony\Component\Messenger\Stamp\StampInterface;
 use Symfony\Component\Scheduler\Messenger\ScheduledStamp;
 use Zenstruck\Messenger\Monitor\Schedule\TaskInfo;
 
@@ -19,7 +18,7 @@ use Zenstruck\Messenger\Monitor\Schedule\TaskInfo;
  * @author Kevin Bond <kevinbond@gmail.com>
  */
 #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
-final class TagStamp implements StampInterface, \Stringable
+final class TagStamp extends AttributeStamp implements \Stringable
 {
     public function __construct(
         public readonly string $value,

--- a/tests/Feature/BundleServicesTest.php
+++ b/tests/Feature/BundleServicesTest.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/messenger-monitor-bundle package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Messenger\Monitor\Tests\Feature;
+
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Messenger\Monitor\Tests\Fixture\TestService;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class BundleServicesTest extends KernelTestCase
+{
+    /**
+     * @test
+     */
+    public function autowires_services(): void
+    {
+        /** @var TestService $service */
+        $service = self::getContainer()->get(TestService::class);
+
+        $this->assertCount(1, $service->transports);
+        $this->assertCount(0, $service->workers);
+        $this->assertCount(0, $service->schedules);
+    }
+}

--- a/tests/Feature/HistoryTest.php
+++ b/tests/Feature/HistoryTest.php
@@ -1,0 +1,168 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/messenger-monitor-bundle package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Messenger\Monitor\Tests\Feature;
+
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Messenger\Exception\HandlerFailedException;
+use Symfony\Component\Messenger\Exception\NoHandlerForMessageException;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+use Zenstruck\Messenger\Monitor\Tests\Fixture\Factory\ProcessedMessageFactory;
+use Zenstruck\Messenger\Monitor\Tests\Fixture\Message\MessageA;
+use Zenstruck\Messenger\Monitor\Tests\Fixture\Message\MessageAHandler;
+use Zenstruck\Messenger\Monitor\Tests\Fixture\Message\MessageB;
+use Zenstruck\Messenger\Monitor\Tests\Fixture\Message\MessageC;
+use Zenstruck\Messenger\Monitor\Tests\Fixture\Message\MessageCHandler1;
+use Zenstruck\Messenger\Monitor\Tests\Fixture\Message\MessageCHandler2;
+use Zenstruck\Messenger\Test\InteractsWithMessenger;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class HistoryTest extends KernelTestCase
+{
+    use Factories, InteractsWithMessenger, ResetDatabase;
+
+    /**
+     * @test
+     */
+    public function flow_for_single_handler(): void
+    {
+        ProcessedMessageFactory::assert()->empty();
+
+        $this->bus()->dispatch(new MessageA(return: 'foo'));
+
+        $this->transport()->processOrFail(1);
+
+        ProcessedMessageFactory::assert()->count(1);
+
+        $message = ProcessedMessageFactory::first();
+        $this->assertSame(MessageA::class, $message->type()->class());
+        $this->assertSame('async', $message->transport());
+        $this->assertFalse($message->isFailure());
+        $this->assertCount(1, $message->results());
+        $this->assertSame(['data' => 'foo'], $message->results()->all()[0]->data());
+        $this->assertFalse($message->results()->all()[0]->isFailure());
+        $this->assertSame(MessageAHandler::class, $message->results()->all()[0]->handler()?->class());
+        $this->assertNull($message->results()->all()[0]->handler()?->description());
+    }
+
+    /**
+     * @test
+     */
+    public function flow_for_single_handler_failure(): void
+    {
+        ProcessedMessageFactory::assert()->empty();
+
+        $this->bus()->dispatch(new MessageA(return: 'foo', throw: true));
+
+        $this->transport()->processOrFail(1);
+
+        ProcessedMessageFactory::assert()->count(1);
+
+        $message = ProcessedMessageFactory::first();
+        $this->assertSame(MessageA::class, $message->type()->class());
+        $this->assertTrue($message->isFailure());
+        $this->assertSame(HandlerFailedException::class, $message->failure()?->class());
+        $this->assertSame(\sprintf('Handling "%s" failed: error', MessageA::class), $message->failure()->description());
+        $this->assertCount(1, $message->results());
+        $this->assertTrue($message->results()->all()[0]->isFailure());
+        $this->assertSame(\RuntimeException::class, $message->results()->all()[0]->failure()?->class());
+        $this->assertSame('error', $message->results()->all()[0]->failure()->description());
+        $this->assertSame(MessageAHandler::class, $message->results()->all()[0]->handler()?->class());
+        $this->assertSame(['stack_trace'], \array_keys($message->results()->all()[0]->data()));
+    }
+
+    /**
+     * @test
+     */
+    public function flow_for_missing_handler(): void
+    {
+        ProcessedMessageFactory::assert()->empty();
+
+        $this->bus()->dispatch(new MessageB());
+
+        $this->transport()->processOrFail(1);
+
+        ProcessedMessageFactory::assert()->count(1);
+
+        $message = ProcessedMessageFactory::first();
+
+        $this->assertTrue($message->isFailure());
+        $this->assertSame(NoHandlerForMessageException::class, $message->failure()?->class());
+        $this->assertSame(\sprintf('No handler for message "%s".', MessageB::class), $message->failure()->description());
+        $this->assertEmpty($message->results()->all());
+    }
+
+    /**
+     * @test
+     */
+    public function flow_for_multiple_handlers(): void
+    {
+        ProcessedMessageFactory::assert()->empty();
+
+        $this->bus()->dispatch(new MessageC(return1: 'foo', return2: 'bar'));
+
+        $this->transport()->processOrFail(1);
+
+        ProcessedMessageFactory::assert()->count(1);
+
+        $message = ProcessedMessageFactory::first();
+        $this->assertSame(MessageC::class, $message->type()->class());
+        $this->assertSame('async', $message->transport());
+        $this->assertFalse($message->isFailure());
+        $this->assertCount(2, $message->results());
+
+        $this->assertSame(['data' => 'foo'], $message->results()->all()[0]->data());
+        $this->assertFalse($message->results()->all()[0]->isFailure());
+        $this->assertSame(MessageCHandler1::class, $message->results()->all()[0]->handler()?->class());
+        $this->assertNull($message->results()->all()[0]->handler()?->description());
+
+        $this->assertSame(['data' => 'bar'], $message->results()->all()[1]->data());
+        $this->assertFalse($message->results()->all()[1]->isFailure());
+        $this->assertSame(MessageCHandler2::class, $message->results()->all()[1]->handler()?->class());
+        $this->assertSame('handle', $message->results()->all()[1]->handler()?->description());
+    }
+
+    /**
+     * @test
+     */
+    public function flow_for_multiple_handlers_one_fails(): void
+    {
+        $this->bus()->dispatch(new MessageC(return1: 'foo', return2: 'bar', throw: true));
+
+        $this->transport()->processOrFail(1);
+
+        ProcessedMessageFactory::assert()->count(1);
+
+        $message = ProcessedMessageFactory::first();
+        $this->assertSame(MessageC::class, $message->type()->class());
+        $this->assertSame('async', $message->transport());
+        $this->assertTrue($message->isFailure());
+
+        $this->assertSame(HandlerFailedException::class, $message->failure()?->class());
+        $this->assertSame(\sprintf('Handling "%s" failed: error', MessageC::class), $message->failure()->description());
+        $this->assertCount(2, $message->results());
+
+        $this->assertSame(['data' => 'bar'], $message->results()->all()[0]->data());
+        $this->assertFalse($message->results()->all()[0]->isFailure());
+        $this->assertSame(MessageCHandler2::class, $message->results()->all()[0]->handler()?->class());
+        $this->assertSame('handle', $message->results()->all()[0]->handler()?->description());
+
+        $this->assertTrue($message->results()->all()[1]->isFailure());
+        $this->assertSame(MessageCHandler1::class, $message->results()->all()[1]->handler()?->class());
+        $this->assertNull($message->results()->all()[1]->handler()?->description());
+        $this->assertSame(\RuntimeException::class, $message->results()->all()[1]->failure()?->class());
+        $this->assertSame('error', $message->results()->all()[1]->failure()->description());
+        $this->assertSame(['stack_trace'], \array_keys($message->results()->all()[1]->data()));
+    }
+}

--- a/tests/Feature/SerializerTest.php
+++ b/tests/Feature/SerializerTest.php
@@ -9,47 +9,19 @@
  * file that was distributed with this source code.
  */
 
-namespace Zenstruck\Messenger\Monitor\Tests\Integration;
+namespace Zenstruck\Messenger\Monitor\Tests\Feature;
 
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Clock\Test\ClockSensitiveTrait;
 use Symfony\Component\Serializer\Serializer;
-use Zenstruck\Console\Test\InteractsWithConsole;
-use Zenstruck\Foundry\Test\ResetDatabase;
 use Zenstruck\Messenger\Monitor\Stamp\MonitorStamp;
-use Zenstruck\Messenger\Monitor\Tests\Fixture\TestService;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  */
-final class ZenstruckMessengerMonitorBundleTest extends KernelTestCase
+final class SerializerTest extends KernelTestCase
 {
-    use ClockSensitiveTrait, InteractsWithConsole, ResetDatabase;
-
-    /**
-     * @test
-     */
-    public function autowires_services(): void
-    {
-        /** @var TestService $service */
-        $service = self::getContainer()->get(TestService::class);
-
-        $this->assertCount(1, $service->transports);
-        $this->assertCount(0, $service->workers);
-        $this->assertCount(0, $service->schedules);
-    }
-
-    /**
-     * @test
-     */
-    public function run_messenger_monitor_command(): void
-    {
-        $this->executeConsoleCommand('messenger:monitor')
-            ->assertSuccessful()
-            ->assertOutputContains('[!] No workers running.')
-            ->assertOutputContains('async   n/a')
-        ;
-    }
+    use ClockSensitiveTrait;
 
     /**
      * @test

--- a/tests/Fixture/Message/MessageAHandler.php
+++ b/tests/Fixture/Message/MessageAHandler.php
@@ -11,14 +11,20 @@
 
 namespace Zenstruck\Messenger\Monitor\Tests\Fixture\Message;
 
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  */
-final class MessageA
+#[AsMessageHandler]
+final class MessageAHandler
 {
-    public function __construct(
-        public readonly mixed $return = null,
-        public readonly bool $throw = false,
-    ) {
+    public function __invoke(MessageA $message): mixed
+    {
+        if ($message->throw) {
+            throw new \RuntimeException('error');
+        }
+
+        return $message->return;
     }
 }

--- a/tests/Fixture/Message/MessageC.php
+++ b/tests/Fixture/Message/MessageC.php
@@ -14,10 +14,11 @@ namespace Zenstruck\Messenger\Monitor\Tests\Fixture\Message;
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  */
-final class MessageA
+final class MessageC
 {
     public function __construct(
-        public readonly mixed $return = null,
+        public readonly mixed $return1 = null,
+        public readonly mixed $return2 = null,
         public readonly bool $throw = false,
     ) {
     }

--- a/tests/Fixture/Message/MessageCHandler1.php
+++ b/tests/Fixture/Message/MessageCHandler1.php
@@ -11,14 +11,20 @@
 
 namespace Zenstruck\Messenger\Monitor\Tests\Fixture\Message;
 
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  */
-final class MessageA
+#[AsMessageHandler]
+final class MessageCHandler1
 {
-    public function __construct(
-        public readonly mixed $return = null,
-        public readonly bool $throw = false,
-    ) {
+    public function __invoke(MessageC $message): mixed
+    {
+        if ($message->throw) {
+            throw new \RuntimeException('error');
+        }
+
+        return $message->return1;
     }
 }

--- a/tests/Fixture/Message/MessageCHandler2.php
+++ b/tests/Fixture/Message/MessageCHandler2.php
@@ -11,14 +11,16 @@
 
 namespace Zenstruck\Messenger\Monitor\Tests\Fixture\Message;
 
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  */
-final class MessageA
+final class MessageCHandler2
 {
-    public function __construct(
-        public readonly mixed $return = null,
-        public readonly bool $throw = false,
-    ) {
+    #[AsMessageHandler]
+    public function handle(MessageC $message): mixed
+    {
+        return $message->return2;
     }
 }

--- a/tests/Fixture/TestKernel.php
+++ b/tests/Fixture/TestKernel.php
@@ -20,7 +20,14 @@ use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
 use Zenstruck\Foundry\ZenstruckFoundryBundle;
 use Zenstruck\Messenger\Monitor\Tests\Fixture\Entity\ProcessedMessage;
+use Zenstruck\Messenger\Monitor\Tests\Fixture\Message\MessageA;
+use Zenstruck\Messenger\Monitor\Tests\Fixture\Message\MessageAHandler;
+use Zenstruck\Messenger\Monitor\Tests\Fixture\Message\MessageB;
+use Zenstruck\Messenger\Monitor\Tests\Fixture\Message\MessageC;
+use Zenstruck\Messenger\Monitor\Tests\Fixture\Message\MessageCHandler1;
+use Zenstruck\Messenger\Monitor\Tests\Fixture\Message\MessageCHandler2;
 use Zenstruck\Messenger\Monitor\ZenstruckMessengerMonitorBundle;
+use Zenstruck\Messenger\Test\ZenstruckMessengerTestBundle;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
@@ -33,6 +40,7 @@ final class TestKernel extends Kernel
     {
         yield new FrameworkBundle();
         yield new DoctrineBundle();
+        yield new ZenstruckMessengerTestBundle();
         yield new ZenstruckFoundryBundle();
         yield new ZenstruckMessengerMonitorBundle();
     }
@@ -47,7 +55,12 @@ final class TestKernel extends Kernel
             'serializer' => true,
             'messenger' => [
                 'transports' => [
-                    'async' => 'in-memory://',
+                    'async' => 'test://',
+                ],
+                'routing' => [
+                    MessageA::class => 'async',
+                    MessageB::class => 'async',
+                    MessageC::class => 'async',
                 ],
             ],
         ]);
@@ -78,6 +91,9 @@ final class TestKernel extends Kernel
         ]);
 
         $c->register(TestService::class)->setAutowired(true)->setPublic(true);
+        $c->register(MessageAHandler::class)->setAutowired(true)->setAutoconfigured(true);
+        $c->register(MessageCHandler1::class)->setAutowired(true)->setAutoconfigured(true);
+        $c->register(MessageCHandler2::class)->setAutowired(true)->setAutoconfigured(true);
     }
 
     protected function configureRoutes(RoutingConfigurator $routes): void

--- a/tests/Integration/Command/MonitorCommandTest.php
+++ b/tests/Integration/Command/MonitorCommandTest.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/messenger-monitor-bundle package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Messenger\Monitor\Tests\Integration\Command;
+
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Console\Test\InteractsWithConsole;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class MonitorCommandTest extends KernelTestCase
+{
+    use InteractsWithConsole, ResetDatabase;
+
+    /**
+     * @test
+     */
+    public function run_messenger_monitor_command(): void
+    {
+        $this->executeConsoleCommand('messenger:monitor')
+            ->assertSuccessful()
+            ->assertOutputContains('[!] No workers running.')
+            ->assertOutputContains('async   0                 0')
+        ;
+    }
+}

--- a/tests/Integration/DependencyInjection/ZenstruckMessengerMonitorExtensionTest.php
+++ b/tests/Integration/DependencyInjection/ZenstruckMessengerMonitorExtensionTest.php
@@ -66,7 +66,7 @@ final class ZenstruckMessengerMonitorExtensionTest extends AbstractExtensionTest
     {
         $this->load(['storage' => [
             'orm' => ['entity_class' => ProcessedMessageImpl::class],
-            'exclude' => ['stdClass']
+            'exclude' => ['stdClass'],
         ]]);
 
         $this->assertContainerBuilderHasServiceDefinitionWithArgument('.zenstruck_messenger_monitor.history.listener', 2, [\stdClass::class]);
@@ -80,7 +80,7 @@ final class ZenstruckMessengerMonitorExtensionTest extends AbstractExtensionTest
         $this->expectException(InvalidConfigurationException::class);
 
         $this->load(['storage' => [
-            'exclude' => ['invalid']
+            'exclude' => ['invalid'],
         ]]);
     }
 

--- a/tests/Integration/DependencyInjection/ZenstruckMessengerMonitorExtensionTest.php
+++ b/tests/Integration/DependencyInjection/ZenstruckMessengerMonitorExtensionTest.php
@@ -17,7 +17,9 @@ use Matthias\SymfonyDependencyInjectionTest\PhpUnit\ContainerBuilderHasServiceDe
 use PHPUnit\Framework\Constraint\LogicalNot;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Zenstruck\Messenger\Monitor\DependencyInjection\ZenstruckMessengerMonitorExtension;
-use Zenstruck\Messenger\Monitor\History\HistoryListener;
+use Zenstruck\Messenger\Monitor\EventListener\AddMonitorStampListener;
+use Zenstruck\Messenger\Monitor\EventListener\HandleMonitorStampListener;
+use Zenstruck\Messenger\Monitor\EventListener\ReceiveMonitorStampListener;
 use Zenstruck\Messenger\Monitor\History\Model\ProcessedMessage;
 use Zenstruck\Messenger\Monitor\History\Storage;
 use Zenstruck\Messenger\Monitor\History\Storage\ORMStorage;
@@ -40,7 +42,9 @@ final class ZenstruckMessengerMonitorExtensionTest extends AbstractExtensionTest
         $this->assertContainerBuilderHasAlias(Transports::class, 'zenstruck_messenger_monitor.transports');
         $this->assertContainerBuilderHasAlias(Workers::class, 'zenstruck_messenger_monitor.workers');
         $this->assertThat($this->container, new LogicalNot(new ContainerBuilderHasAliasConstraint(Storage::class)));
-        $this->assertThat($this->container, new LogicalNot(new ContainerBuilderHasServiceDefinitionConstraint('.zenstruck_messenger_monitor.history.listener')));
+        $this->assertThat($this->container, new LogicalNot(new ContainerBuilderHasServiceDefinitionConstraint('.zenstruck_messenger_monitor.listener.add_monitor_stamp')));
+        $this->assertThat($this->container, new LogicalNot(new ContainerBuilderHasServiceDefinitionConstraint('.zenstruck_messenger_monitor.listener.receive_monitor_stamp')));
+        $this->assertThat($this->container, new LogicalNot(new ContainerBuilderHasServiceDefinitionConstraint('.zenstruck_messenger_monitor.listener.handle_monitor_stamp')));
     }
 
     /**
@@ -55,8 +59,10 @@ final class ZenstruckMessengerMonitorExtensionTest extends AbstractExtensionTest
         $this->assertContainerBuilderHasService('zenstruck_messenger_monitor.history.storage', ORMStorage::class);
         $this->assertContainerBuilderHasServiceDefinitionWithArgument('zenstruck_messenger_monitor.history.storage', 1, ProcessedMessageImpl::class);
         $this->assertContainerBuilderHasAlias(Storage::class, 'zenstruck_messenger_monitor.history.storage');
-        $this->assertContainerBuilderHasService('.zenstruck_messenger_monitor.history.listener', HistoryListener::class);
-        $this->assertContainerBuilderHasServiceDefinitionWithArgument('.zenstruck_messenger_monitor.history.listener', 2, []);
+        $this->assertContainerBuilderHasService('.zenstruck_messenger_monitor.listener.add_monitor_stamp', AddMonitorStampListener::class);
+        $this->assertContainerBuilderHasService('.zenstruck_messenger_monitor.listener.receive_monitor_stamp', ReceiveMonitorStampListener::class);
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument('.zenstruck_messenger_monitor.listener.receive_monitor_stamp', 0, []);
+        $this->assertContainerBuilderHasService('.zenstruck_messenger_monitor.listener.handle_monitor_stamp', HandleMonitorStampListener::class);
     }
 
     /**
@@ -69,7 +75,7 @@ final class ZenstruckMessengerMonitorExtensionTest extends AbstractExtensionTest
             'exclude' => ['stdClass'],
         ]]);
 
-        $this->assertContainerBuilderHasServiceDefinitionWithArgument('.zenstruck_messenger_monitor.history.listener', 2, [\stdClass::class]);
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument('.zenstruck_messenger_monitor.listener.receive_monitor_stamp', 0, [\stdClass::class]);
     }
 
     /**

--- a/tests/Integration/DependencyInjection/ZenstruckMessengerMonitorExtensionTest.php
+++ b/tests/Integration/DependencyInjection/ZenstruckMessengerMonitorExtensionTest.php
@@ -13,9 +13,11 @@ namespace Zenstruck\Messenger\Monitor\Tests\Integration\DependencyInjection;
 
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\ContainerBuilderHasAliasConstraint;
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\ContainerBuilderHasServiceDefinitionConstraint;
 use PHPUnit\Framework\Constraint\LogicalNot;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Zenstruck\Messenger\Monitor\DependencyInjection\ZenstruckMessengerMonitorExtension;
+use Zenstruck\Messenger\Monitor\History\HistoryListener;
 use Zenstruck\Messenger\Monitor\History\Model\ProcessedMessage;
 use Zenstruck\Messenger\Monitor\History\Storage;
 use Zenstruck\Messenger\Monitor\History\Storage\ORMStorage;
@@ -38,6 +40,7 @@ final class ZenstruckMessengerMonitorExtensionTest extends AbstractExtensionTest
         $this->assertContainerBuilderHasAlias(Transports::class, 'zenstruck_messenger_monitor.transports');
         $this->assertContainerBuilderHasAlias(Workers::class, 'zenstruck_messenger_monitor.workers');
         $this->assertThat($this->container, new LogicalNot(new ContainerBuilderHasAliasConstraint(Storage::class)));
+        $this->assertThat($this->container, new LogicalNot(new ContainerBuilderHasServiceDefinitionConstraint('.zenstruck_messenger_monitor.history.listener')));
     }
 
     /**
@@ -52,6 +55,33 @@ final class ZenstruckMessengerMonitorExtensionTest extends AbstractExtensionTest
         $this->assertContainerBuilderHasService('zenstruck_messenger_monitor.history.storage', ORMStorage::class);
         $this->assertContainerBuilderHasServiceDefinitionWithArgument('zenstruck_messenger_monitor.history.storage', 1, ProcessedMessageImpl::class);
         $this->assertContainerBuilderHasAlias(Storage::class, 'zenstruck_messenger_monitor.history.storage');
+        $this->assertContainerBuilderHasService('.zenstruck_messenger_monitor.history.listener', HistoryListener::class);
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument('.zenstruck_messenger_monitor.history.listener', 2, []);
+    }
+
+    /**
+     * @test
+     */
+    public function storage_with_excluded_classes(): void
+    {
+        $this->load(['storage' => [
+            'orm' => ['entity_class' => ProcessedMessageImpl::class],
+            'exclude' => ['stdClass']
+        ]]);
+
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument('.zenstruck_messenger_monitor.history.listener', 2, [\stdClass::class]);
+    }
+
+    /**
+     * @test
+     */
+    public function invalid_exclude_class(): void
+    {
+        $this->expectException(InvalidConfigurationException::class);
+
+        $this->load(['storage' => [
+            'exclude' => ['invalid']
+        ]]);
     }
 
     /**

--- a/tests/Unit/EventListener/AddMonitorStampListenerTest.php
+++ b/tests/Unit/EventListener/AddMonitorStampListenerTest.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/messenger-monitor-bundle package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Messenger\Monitor\Tests\Unit\EventListener;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Event\SendMessageToTransportsEvent;
+use Zenstruck\Messenger\Monitor\EventListener\AddMonitorStampListener;
+use Zenstruck\Messenger\Monitor\Stamp\MonitorStamp;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class AddMonitorStampListenerTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function adds_monitor_stamp(): void
+    {
+        $listener = new AddMonitorStampListener();
+        $envelope = new Envelope(new \stdClass());
+        $event = new SendMessageToTransportsEvent($envelope, []);
+
+        $this->assertNull($event->getEnvelope()->last(MonitorStamp::class));
+
+        $listener->__invoke($event);
+
+        $this->assertInstanceOf(MonitorStamp::class, $event->getEnvelope()->last(MonitorStamp::class));
+    }
+}

--- a/tests/Unit/EventListener/HandleMonitorStampListenerTest.php
+++ b/tests/Unit/EventListener/HandleMonitorStampListenerTest.php
@@ -1,0 +1,100 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/messenger-monitor-bundle package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Messenger\Monitor\Tests\Unit\EventListener;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Event\WorkerMessageFailedEvent;
+use Symfony\Component\Messenger\Event\WorkerMessageHandledEvent;
+use Symfony\Component\Messenger\Stamp\HandledStamp;
+use Zenstruck\Messenger\Monitor\EventListener\HandleMonitorStampListener;
+use Zenstruck\Messenger\Monitor\History\Model\Results;
+use Zenstruck\Messenger\Monitor\History\ResultNormalizer;
+use Zenstruck\Messenger\Monitor\History\Storage;
+use Zenstruck\Messenger\Monitor\Stamp\MonitorStamp;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class HandleMonitorStampListenerTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function handles_success(): void
+    {
+        $envelope = new Envelope(new \stdClass(), [
+            (new MonitorStamp())->markReceived('foo'),
+            new HandledStamp('handler', 'return'),
+        ]);
+        $storage = $this->createMock(Storage::class);
+        $storage->expects($this->once())->method('save')->with(
+            $this->isInstanceOf(Envelope::class),
+            $this->isInstanceOf(Results::class),
+        );
+
+        $listener = new HandleMonitorStampListener($storage, new ResultNormalizer(__DIR__));
+
+        $listener->handleSuccess($event = new WorkerMessageHandledEvent($envelope, 'foo'));
+
+        $this->assertTrue($event->getEnvelope()->last(MonitorStamp::class)->isFinished());
+    }
+
+    /**
+     * @test
+     */
+    public function handles_success_invalid(): void
+    {
+        $storage = $this->createMock(Storage::class);
+        $storage->expects($this->never())->method('save');
+
+        $listener = new HandleMonitorStampListener($storage, new ResultNormalizer(__DIR__));
+
+        $listener->handleSuccess(new WorkerMessageHandledEvent(new Envelope(new \stdClass()), 'foo'));
+        $listener->handleSuccess(new WorkerMessageHandledEvent(new Envelope(new \stdClass(), [new MonitorStamp()]), 'foo'));
+    }
+
+    /**
+     * @test
+     */
+    public function handles_failure(): void
+    {
+        $envelope = new Envelope(new \stdClass(), [(new MonitorStamp())->markReceived('foo')]);
+        $exception = new \RuntimeException();
+        $storage = $this->createMock(Storage::class);
+        $storage->expects($this->once())->method('save')->with(
+            $this->isInstanceOf(Envelope::class),
+            $this->isInstanceOf(Results::class),
+            $exception,
+        );
+
+        $listener = new HandleMonitorStampListener($storage, new ResultNormalizer(__DIR__));
+
+        $listener->handleFailure($event = new WorkerMessageFailedEvent($envelope, 'foo', $exception));
+
+        $this->assertTrue($event->getEnvelope()->last(MonitorStamp::class)->isFinished());
+    }
+
+    /**
+     * @test
+     */
+    public function handles_failure_invalid(): void
+    {
+        $storage = $this->createMock(Storage::class);
+        $storage->expects($this->never())->method('save');
+
+        $listener = new HandleMonitorStampListener($storage, new ResultNormalizer(__DIR__));
+
+        $listener->handleFailure(new WorkerMessageFailedEvent(new Envelope(new \stdClass()), 'foo', new \RuntimeException()));
+        $listener->handleFailure(new WorkerMessageFailedEvent(new Envelope(new \stdClass(), [new MonitorStamp()]), 'foo', new \RuntimeException()));
+    }
+}

--- a/tests/Unit/History/Model/ResultsTest.php
+++ b/tests/Unit/History/Model/ResultsTest.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/messenger-monitor-bundle package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Messenger\Monitor\Tests\Unit\History\Model;
+
+use PHPUnit\Framework\TestCase;
+use Zenstruck\Messenger\Monitor\History\Model\Results;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class ResultsTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function can_create_with_null(): void
+    {
+        $results = new Results(null);
+
+        $this->assertCount(0, $results);
+        $this->assertSame([], $results->all());
+        $this->assertSame([], $results->successes());
+        $this->assertSame([], $results->failures());
+        $this->assertSame(null, $results->jsonSerialize());
+    }
+}

--- a/tests/Unit/History/Model/ResultsTest.php
+++ b/tests/Unit/History/Model/ResultsTest.php
@@ -30,6 +30,6 @@ final class ResultsTest extends TestCase
         $this->assertSame([], $results->all());
         $this->assertSame([], $results->successes());
         $this->assertSame([], $results->failures());
-        $this->assertSame(null, $results->jsonSerialize());
+        $this->assertNull($results->jsonSerialize());
     }
 }

--- a/tests/Unit/History/Model/TagsTest.php
+++ b/tests/Unit/History/Model/TagsTest.php
@@ -87,7 +87,7 @@ final class TagsTest extends TestCase
             new TagStamp('qux'),
         ]);
 
-        $this->assertSame(['from', 'attribute', 'bar', 'foo', 'baz', 'qux'], (new Tags($envelope))->all());
+        $this->assertSame(['foo', 'bar', 'baz', 'qux', 'from', 'attribute', 'abstract', 'interface'], (new Tags($envelope))->all());
     }
 
     /**
@@ -104,9 +104,19 @@ final class TagsTest extends TestCase
     }
 }
 
+#[TagStamp('interface')]
+interface InterfaceMessage
+{
+}
+
+#[TagStamp('abstract')]
+abstract class AbstractMessage implements InterfaceMessage
+{
+}
+
 #[TagStamp('from')]
 #[TagStamp('attribute')]
 #[TagStamp('bar')]
-class TestMessage
+class TestMessage extends AbstractMessage
 {
 }


### PR DESCRIPTION
- [x] Disable monitoring class/interface in config
- [x] Allow `#[DisableMonitoringStamp]` to be applied as attribute to interfaces
- [x] Split `HistoryListener` (slight perf improvement when adding `MonitorStamp`)
- [x] Improve test coverage
- [x] Allow `#[TagStamp]` to be added to parent classes/interfaces