### PR TITLE
Use jsdelivr for @hotwired/stimulus

### DIFF
--- a/templates/layout.html.twig
+++ b/templates/layout.html.twig
@@ -51,7 +51,7 @@
         <script src="https://cdn.jsdelivr.net/npm/idiomorph@0.3.0/dist/idiomorph-ext.min.js"></script>
 
         <script type="module">
-            import { Application, Controller } from "https://unpkg.com/@hotwired/stimulus/dist/stimulus.js"
+            import { Application, Controller } from "https://cdn.jsdelivr.net/npm/@hotwired/stimulus/+esm"
             window.Stimulus = Application.start()
 
             Stimulus.register('refreshable', class extends Controller {


### PR DESCRIPTION
All the other external assets come from jsdelivr.
Unpkg produces a lot of issues lately:
https://github.com/unpkg/unpkg/issues/412
https://github.com/unpkg/unpkg/issues/440
https://github.com/unpkg/unpkg/issues/443
