### PR TITLE
Fix Twig deprecation

### DIFF
--- a/templates/detail.html.twig
+++ b/templates/detail.html.twig
@@ -141,7 +141,7 @@
                                         <code>null</code>
                                     {% elseif value is iterable %}
                                         <pre class="mb-0" style="white-space: pre; max-height: 340px; overflow: auto;">{{ value|json_encode(constant('JSON_PRETTY_PRINT')) }}</pre>
-                                    {% elseif value matches "\/\n/" %}
+                                    {% elseif value matches "/\n/" %}
                                         <pre class="mb-0" style="white-space: pre; max-height: 340px; overflow: auto;">{{ value }}</pre>
                                     {% else %}
                                         <code>{{ value }}</code>


### PR DESCRIPTION
Fixes deprecation reported here #133: `User Deprecated: Since twig/twig 3.12: Character "/" should not be escaped; the "\" character is ignored in Twig 3 but will not be in Twig 4. Please remove the extra "\" character at position 2 in "@ZenstruckMessengerMonitor/detail.html.twig" at line 144.`
