### PR TITLE
feat: lower priority of HandleMonitorStampListener

### DIFF
--- a/config/storage_orm.php
+++ b/config/storage_orm.php
@@ -45,8 +45,8 @@ return static function (ContainerConfigurator $container): void {
                 service('zenstruck_messenger_monitor.history.storage'),
                 service('.zenstruck_messenger_monitor.history.result_normalizer'),
             ])
-            ->tag('kernel.event_listener', ['method' => 'handleSuccess', 'event' => WorkerMessageHandledEvent::class])
-            ->tag('kernel.event_listener', ['method' => 'handleFailure', 'event' => WorkerMessageFailedEvent::class])
+            ->tag('kernel.event_listener', ['method' => 'handleSuccess', 'event' => WorkerMessageHandledEvent::class, 'priority' => -100])
+            ->tag('kernel.event_listener', ['method' => 'handleFailure', 'event' => WorkerMessageFailedEvent::class, 'priority' => -100])
 
         ->set('.zenstruck_messenger_monitor.command.purge', PurgeCommand::class)
             ->args([

--- a/src/History/Storage/ORMStorage.php
+++ b/src/History/Storage/ORMStorage.php
@@ -90,6 +90,7 @@ final class ORMStorage implements Storage
 
         $om->persist($object);
         $om->flush();
+        $om->clear();
     }
 
     public function delete(mixed $id): void
@@ -102,6 +103,7 @@ final class ORMStorage implements Storage
 
         $om->remove($message);
         $om->flush();
+        $om->clear();
     }
 
     public function availableMessageTypes(Specification $specification): Collection

--- a/src/History/Storage/ORMStorage.php
+++ b/src/History/Storage/ORMStorage.php
@@ -90,7 +90,6 @@ final class ORMStorage implements Storage
 
         $om->persist($object);
         $om->flush();
-        $om->clear();
     }
 
     public function delete(mixed $id): void
@@ -103,7 +102,6 @@ final class ORMStorage implements Storage
 
         $om->remove($message);
         $om->flush();
-        $om->clear();
     }
 
     public function availableMessageTypes(Specification $specification): Collection


### PR DESCRIPTION
call entityManager clear() after flush()

https://github.com/zenstruck/messenger-monitor-bundle/issues/135#issuecomment-2832302946

@priyadi 
Could you please have a look if this is the correct implementation like you suggested?