### PR TITLE
fix(ui): remove need for `app.locale`

### DIFF
--- a/src/Controller/MessengerMonitorController.php
+++ b/src/Controller/MessengerMonitorController.php
@@ -197,14 +197,14 @@ abstract class MessengerMonitorController extends AbstractController
             'schedule' => $helper->schedules->get($name),
             'transports' => $helper->transports->filter()->excludeSync()->excludeSchedules()->excludeFailed(),
             'cron_humanizer' => new class {
-                public function humanize(TriggerInterface $trigger, CronExpressionTrigger $cron, ?string $locale): string
+                public function humanize(TriggerInterface $trigger, CronExpressionTrigger $cron): string
                 {
                     $title = 'Activate humanized version with composer require lorisleiva/cron-translator';
                     $body = (string) $cron;
 
                     if (\class_exists(CronTranslator::class)) {
                         $title = $body;
-                        $body = CronTranslator::translate((string) $cron, $locale ?? 'en');
+                        $body = CronTranslator::translate((string) $cron);
                     }
 
                     return \str_replace((string) $cron, \sprintf('<abbr title="%s">%s</abbr>', $title, $body), (string) $trigger);

--- a/templates/schedule.html.twig
+++ b/templates/schedule.html.twig
@@ -98,7 +98,7 @@
                             </td>
                             <td>
                                 {% if trigger.cron %}
-                                    {{ cron_humanizer.humanize(trigger.get, trigger.inner, app.locale)|raw }}
+                                    {{ cron_humanizer.humanize(trigger.get, trigger.inner)|raw }}
                                 {% else %}
                                     {{ trigger.type.description|capitalize }}
                                 {% endif %}


### PR DESCRIPTION
Fix #138

In apps that don't have translations enabled, `app.locale` throws an exception.