### PR TITLE
fix: change fieldType of memoryUsage from integer to bigint

### DIFF
--- a/config/doctrine/mapping/ProcessedMessage.orm.xml
+++ b/config/doctrine/mapping/ProcessedMessage.orm.xml
@@ -13,7 +13,7 @@
         <field name="finishedAt" column="finished_at" type="datetime_immutable" />
         <field name="waitTime" column="wait_time" type="bigint" />
         <field name="handleTime" column="handle_time" type="bigint" />
-        <field name="memoryUsage" column="memory_usage" type="integer" />
+        <field name="memoryUsage" column="memory_usage" type="bigint" />
         <field name="transport" column="transport" />
         <field name="tags" column="tags" nullable="true" />
         <field name="failureType" column="failure_type" nullable="true" />


### PR DESCRIPTION
Changes the type of the `memoryUsage` field from `integer` to `bigint`. Without this change, we'll get this error if the process memory usage exceeds 2.1 GB:

> DriverException: exception occurred while executing a query: SQLSTATE[22003]: Numeric value out of range: 7 ERROR: value "4592025600" is out of range for type integer CONTEXT: unnamed portal parameter $10 = '...'