### PR TITLE
Add received at timestamp to other attempts

### DIFF
--- a/templates/detail.html.twig
+++ b/templates/detail.html.twig
@@ -168,6 +168,7 @@
                     <tr>
                         <th class="text-center">#</th>
                         <th>Status</th>
+                        <th>Received at</th>
                     </tr>
                     </thead>
                     <tbody>
@@ -191,6 +192,9 @@
                                             {% endif %}
                                         </div>
                                     </div>
+                                </td>
+                                <td>
+                                    {{ other.receivedAt|date('c') }}
                                 </td>
                             </tr>
                         {% endif %}


### PR DESCRIPTION
Show the received at timestamp on other attempts in the detail view.

<img width="1137" height="358" alt="image" src="https://github.com/user-attachments/assets/b23c3886-6bf4-45a7-b277-b0355dba5d64" />
