### PR TITLE
fix: remove deprecated $aliasMap parameter from createXmlMappingDriver

### DIFF
--- a/src/ZenstruckMessengerMonitorBundle.php
+++ b/src/ZenstruckMessengerMonitorBundle.php
@@ -25,13 +25,23 @@ final class ZenstruckMessengerMonitorBundle extends Bundle
         parent::build($container);
 
         if (\class_exists(DoctrineOrmMappingsPass::class)) {
-            $container->addCompilerPass(DoctrineOrmMappingsPass::createXmlMappingDriver(
-                [__DIR__.'/../config/doctrine/mapping' => 'Zenstruck\Messenger\Monitor\History\Model'],
-                ['zenstruck_messenger_monitor.history.orm_manager'],
-                'zenstruck_messenger_monitor.history.orm_enabled',
-                [],
-                true,
-            ));
+            $reflection = new \ReflectionClass(DoctrineOrmMappingsPass::class);
+            if ($reflection->getMethod('createXmlMappingDriver')->getParameters()[3]->getName() === 'aliasMap') {
+                $container->addCompilerPass(DoctrineOrmMappingsPass::createXmlMappingDriver(
+                    [__DIR__.'/../config/doctrine/mapping' => 'Zenstruck\Messenger\Monitor\History\Model'],
+                    ['zenstruck_messenger_monitor.history.orm_manager'],
+                    'zenstruck_messenger_monitor.history.orm_enabled',
+                    [],
+                    true,
+                ));
+            } else {
+                $container->addCompilerPass(DoctrineOrmMappingsPass::createXmlMappingDriver(
+                    [__DIR__.'/../config/doctrine/mapping' => 'Zenstruck\Messenger\Monitor\History\Model'],
+                    ['zenstruck_messenger_monitor.history.orm_manager'],
+                    'zenstruck_messenger_monitor.history.orm_enabled',
+                    true, // @phpstan-ignore-line
+                ));
+            }
         }
     }
 


### PR DESCRIPTION
While I added a PR to the doctrine bundle to restore the BC, it would be good to just fix the code right away anyways :)

Fixes #174 