### PR TITLE
Add support for customizable Doctrine entity managers in ORM storage …

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,14 @@ historical snapshot whose period can be customized with the `--period` option.
                 entity_class: App\Entity\ProcessedMessage
     ```
     > [!NOTE]
-    > If you are using a different entity manager, you must also set the `zenstruck_messenger_monitor.history.orm_manager` parameter to the name of that manager.
+    > If you are using a different entity manager, set the `entity_manager` option:
+    > ```yaml
+    > zenstruck_messenger_monitor:
+    >     storage:
+    >         orm:
+    >             entity_class: App\Entity\ProcessedMessage
+    >             entity_manager: custom
+    > ```
 
 3. Clear Cache:
     ```bash
@@ -319,6 +326,9 @@ zenstruck_messenger_monitor:
 
             # Your Doctrine entity class that extends "Zenstruck\Messenger\Monitor\History\Model\ProcessedMessage"
             entity_class:         ~
+
+            # Doctrine entity manager to use.
+            entity_manager:       default
     cache:
       pool: app.cache # If using workers in docker. You can use shared cache pool for all workers
       expired_worker_ttl:  3600

--- a/config/storage_orm.php
+++ b/config/storage_orm.php
@@ -18,7 +18,6 @@ use Zenstruck\Messenger\Monitor\History\Storage\ORMStorage;
 return static function (ContainerConfigurator $container): void {
     $container->parameters()
         ->set('zenstruck_messenger_monitor.history.orm_enabled', true)
-        ->set('zenstruck_messenger_monitor.history.orm_manager', 'default')
     ;
 
     $container->services()

--- a/src/DependencyInjection/ZenstruckMessengerMonitorExtension.php
+++ b/src/DependencyInjection/ZenstruckMessengerMonitorExtension.php
@@ -53,6 +53,10 @@ final class ZenstruckMessengerMonitorExtension extends ConfigurableExtension imp
                                         ->thenInvalid(\sprintf('Your Doctrine entity class must extend "%s"', ProcessedMessage::class))
                                     ->end()
                                 ->end()
+                                ->scalarNode('entity_manager')
+                                    ->info('Doctrine entity manager to use.')
+                                    ->defaultValue('default')
+                                ->end()
                             ->end()
                         ->end()
                     ->end()
@@ -100,6 +104,10 @@ final class ZenstruckMessengerMonitorExtension extends ConfigurableExtension imp
 
         if ($entity = $mergedConfig['storage']['orm']['entity_class'] ?? null) {
             $loader->load('storage_orm.php');
+            $container->setParameter(
+                'zenstruck_messenger_monitor.history.orm_manager',
+                $mergedConfig['storage']['orm']['entity_manager']
+            );
             $container->getDefinition('zenstruck_messenger_monitor.history.storage')
                 ->setArgument(1, $entity)
             ;

--- a/tests/Integration/DependencyInjection/ZenstruckMessengerMonitorExtensionTest.php
+++ b/tests/Integration/DependencyInjection/ZenstruckMessengerMonitorExtensionTest.php
@@ -68,6 +68,26 @@ final class ZenstruckMessengerMonitorExtensionTest extends AbstractExtensionTest
     /**
      * @test
      */
+    public function orm_config_uses_default_entity_manager(): void
+    {
+        $this->load(['storage' => ['orm' => ['entity_class' => ProcessedMessageImpl::class]]]);
+
+        $this->assertContainerBuilderHasParameter('zenstruck_messenger_monitor.history.orm_manager', 'default');
+    }
+
+    /**
+     * @test
+     */
+    public function orm_config_with_custom_entity_manager(): void
+    {
+        $this->load(['storage' => ['orm' => ['entity_class' => ProcessedMessageImpl::class, 'entity_manager' => 'custom']]]);
+
+        $this->assertContainerBuilderHasParameter('zenstruck_messenger_monitor.history.orm_manager', 'custom');
+    }
+
+    /**
+     * @test
+     */
     public function storage_with_excluded_classes(): void
     {
         $this->load(['storage' => [


### PR DESCRIPTION
Fi #181 
add option entity_manager
```yaml
zenstruck_messenger_monitor:
    storage:
        orm:
                entity_manager: my_entity_manager
```
