### PR TITLE
feat: allow disabling the automatic monitor stamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,24 @@ You may want to disable monitoring for certain messages. There are several ways 
             exclude:
                 - App\Message\MyMessage
     ```
+4. Turn monitoring into an opt-in by disabling `auto_stamp`, then stamp the messages you do want
+   to monitor:
+    ```yaml
+    # config/packages/zenstruck_messenger_monitor.yaml
+
+    zenstruck_messenger_monitor:
+        storage:
+            auto_stamp: false
+    ```
+    ```php
+    use Zenstruck\Messenger\Monitor\Stamp\MonitorStamp;
+
+    /** @var \Symfony\Component\Messenger\MessageBusInterface $bus */
+
+    $bus->dispatch(new MyMessage(), [new MonitorStamp()])
+    ```
+    This is what you want when the messages are consumed by another application that does not have
+    this bundle installed: without the stamp, that application has nothing to decode.
 
 #### Description
 
@@ -313,6 +331,10 @@ when@dev:
 ```yaml
 zenstruck_messenger_monitor:
     storage:
+
+        # Whether to stamp every dispatched message. Disable to only monitor the messages you stamp yourself.
+        auto_stamp:           true
+
         # Message classes to disable monitoring for (can be abstract/interface)
         exclude:              []
         orm:

--- a/src/DependencyInjection/ZenstruckMessengerMonitorExtension.php
+++ b/src/DependencyInjection/ZenstruckMessengerMonitorExtension.php
@@ -35,6 +35,10 @@ final class ZenstruckMessengerMonitorExtension extends ConfigurableExtension imp
             ->children()
                 ->arrayNode('storage')
                     ->children()
+                        ->booleanNode('auto_stamp')
+                            ->info('Whether to stamp every dispatched message. Disable to only monitor the messages you stamp yourself.')
+                            ->defaultTrue()
+                        ->end()
                         ->arrayNode('exclude')
                             ->info('Message classes to disable monitoring for (can be abstract/interface)')
                             ->scalarPrototype()
@@ -106,6 +110,10 @@ final class ZenstruckMessengerMonitorExtension extends ConfigurableExtension imp
             $container->getDefinition('.zenstruck_messenger_monitor.listener.receive_monitor_stamp')
                 ->setArgument(0, $mergedConfig['storage']['exclude'])
             ;
+
+            if (!$mergedConfig['storage']['auto_stamp']) {
+                $container->removeDefinition('.zenstruck_messenger_monitor.listener.add_monitor_stamp');
+            }
 
             if (!\class_exists(Schedule::class)) {
                 $container->removeDefinition('.zenstruck_messenger_monitor.command.schedule_purge');

--- a/src/Stamp/MonitorStamp.php
+++ b/src/Stamp/MonitorStamp.php
@@ -18,8 +18,6 @@ use function Symfony\Component\Clock\now;
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  *
- * @internal
- *
  * @phpstan-type MonitorStampData array{
  *     runId: int,
  *     dispatchedAt: \DateTimeImmutable,

--- a/tests/Integration/DependencyInjection/ZenstruckMessengerMonitorExtensionTest.php
+++ b/tests/Integration/DependencyInjection/ZenstruckMessengerMonitorExtensionTest.php
@@ -68,6 +68,21 @@ final class ZenstruckMessengerMonitorExtensionTest extends AbstractExtensionTest
     /**
      * @test
      */
+    public function storage_without_auto_stamp(): void
+    {
+        $this->load(['storage' => [
+            'orm' => ['entity_class' => ProcessedMessageImpl::class],
+            'auto_stamp' => false,
+        ]]);
+
+        $this->assertThat($this->container, new LogicalNot(new ContainerBuilderHasServiceDefinitionConstraint('.zenstruck_messenger_monitor.listener.add_monitor_stamp')));
+        $this->assertContainerBuilderHasService('.zenstruck_messenger_monitor.listener.receive_monitor_stamp', ReceiveMonitorStampListener::class);
+        $this->assertContainerBuilderHasService('.zenstruck_messenger_monitor.listener.handle_monitor_stamp', HandleMonitorStampListener::class);
+    }
+
+    /**
+     * @test
+     */
     public function storage_with_excluded_classes(): void
     {
         $this->load(['storage' => [


### PR DESCRIPTION
Closes #123, implementing what you settled on there: *"an option to disable the `AddMonitorStampListener` is best. This would effectively make the system opt-in."*

`storage.auto_stamp: false` removes the listener definition, so only the messages the application stamps itself are monitored. That is what the reporter needs: their second application does not have the bundle installed and cannot decode a `MonitorStamp`, which fails the worker rather than merely losing the history.

One thing I would like your call on. Making monitoring opt-in means asking people to write `new MonitorStamp()`, and the class is currently `@internal`, so I removed that tag. It is arguably already public in practice, since it travels serialized between applications, but it is your call and I am happy to revert it and document something else instead. The rest of the stamp's API (`withTransport()`, `withReceivedAt()`, ...) stays as it is.

The option lives under `storage` next to `exclude`, since the listener only exists when storage is configured, and both answer the same question of what gets recorded.

The `Full Default Bundle Configuration` block in the README was checked against the actual `config:dump-reference` output.
